### PR TITLE
Implemented load from current_config

### DIFF
--- a/src/sidepanel.js
+++ b/src/sidepanel.js
@@ -267,7 +267,7 @@ export class SidePanel extends React.Component {
   }
 
   loadCurrentConfig() {
-    this.loadYaml(FLASKURL + "/api/getcurrentconfigfile", {
+    this.loadYaml(FLASKURL + "/api/getworkingconfigfile", {
           method: "GET",
           headers: {"Content-Type": "text/html"},
           cache: "no-cache",

--- a/src/sidepanel.js
+++ b/src/sidepanel.js
@@ -101,6 +101,7 @@ export class SidePanel extends React.Component {
     } catch (err) {
       console.log("camilladsp offline");
     }
+    this.loadCurrentConfig();
   }
 
   componentWillUnmount() {
@@ -265,6 +266,15 @@ export class SidePanel extends React.Component {
     });
   }
 
+  loadCurrentConfig() {
+    this.loadYaml(FLASKURL + "/api/getcurrentconfigfile", {
+          method: "GET",
+          headers: {"Content-Type": "text/html"},
+          cache: "no-cache",
+        }
+    );
+  }
+
   loadFile(event) {
     var file = event.target.files[0];
     var reader = new FileReader();
@@ -272,20 +282,18 @@ export class SidePanel extends React.Component {
     reader.onload = (readerEvent) => {
       var content = readerEvent.target.result;
       console.log(content);
-      this.loadYaml(content);
+      this.loadYaml(FLASKURL + "/api/ymltojson", {
+            method: "POST",
+            headers: { "Content-Type": "text/html" },
+            cache: "no-cache",
+            body: content,
+          }
+      );
     };
   }
 
-  async loadYaml(data) {
-    const conf_req = await fetch(FLASKURL + "/api/ymltojson", {
-      method: "POST",
-      //mode: "same-origin",
-      headers: {
-        "Content-Type": "text/html",
-      },
-      cache: "no-cache",
-      body: data,
-    });
+  async loadYaml(url, requestParams) {
+    const conf_req = await fetch(url, requestParams);
     const config = await conf_req.json();
     console.log(config);
     this.setState((state) => {


### PR DESCRIPTION
This is part of the implementation of https://github.com/HEnquist/camillagui-backend/issues/8.
Requires the new `/api/getcurrentconfigfile` endpoint from https://github.com/HEnquist/camillagui-backend/pull/9.

On page load, the `current_config` from the server settings is retrieved and applied.