### PR TITLE
Stdin device: extra_samples, skip_bytes, read_bytes

### DIFF
--- a/src/devices.js
+++ b/src/devices.js
@@ -109,7 +109,14 @@ export class Capture extends React.Component {
       skip_bytes: 0,
       read_bytes: 0,
     },
-    Stdin: { type: "Stdin", channels: 2, format: "S32LE" },
+    Stdin: {
+      type: "Stdin",
+      channels: 2,
+      format: "S32LE",
+      extra_samples: 0,
+      skip_bytes: 0,
+      read_bytes: 0,
+    },
     Pulse: { type: "Pulse", channels: 2, format: "S32LE", device: "something" },
     Wasapi: {
       type: "Wasapi",


### PR DESCRIPTION
`extra_samples`, `skip_bytes`, `read_bytes` are now visible by default when selecting "stdin"

Before, they were only visible after loading a yaml config or getting the active config from CamillaDSP.