### PR TITLE
Devices options grouped into categories

### DIFF
--- a/src/devices.js
+++ b/src/devices.js
@@ -49,27 +49,44 @@ export class Devices extends React.Component {
     });
   }
 
+  group(title, propertyNames) {
+    var properties = propertyNames.map((property) => {
+      return (
+          <ParameterInput
+              parameters={{[property]: this.state.config[property]}}
+              onChange={this.handleChangeParams}
+          />
+      );
+    });
+    return (
+        <>
+          <div className="desc">{title}</div>
+          <div className="group">
+            {properties}
+          </div>
+        </>
+    );
+  }
+
   render() {
     return (
       <div className="devices">
-        <div>
           <ParameterInput
-            parameters={this.state.config}
+            parameters={{samplerate: this.state.config.samplerate}}
             onChange={this.handleChangeParams}
           />
-        </div>
-        <div>
-          <Playback
-            parameters={this.state.config.playback}
-            onChange={this.handlePlayback}
-          />
-        </div>
-        <div>
+          {this.group('Buffers', ['chunksize', 'target_level', 'queuelimit'])}
+          {this.group('Silence', ['silence_threshold', 'silence_timeout'])}
+          {this.group('Rate adjust', ['enable_rate_adjust', 'adjust_period'])}
+          {this.group('Resampling', ['enable_resampling', 'resampler_type', 'capture_samplerate'])}
           <Capture
             parameters={this.state.config.capture}
             onChange={this.handleCapture}
           />
-        </div>
+          <Playback
+            parameters={this.state.config.playback}
+            onChange={this.handlePlayback}
+          />
       </div>
     );
   }
@@ -152,7 +169,7 @@ export class Capture extends React.Component {
     return (
       <div>
         <div className="desc">Capture device</div>
-        <div className="device">
+        <div className="group">
           <div className="row">
             <EnumSelect
               desc="type"
@@ -238,7 +255,7 @@ export class Playback extends React.Component {
     return (
       <div>
         <div className="desc">Playback device</div>
-        <div className="device">
+        <div className="group">
           <div className="row">
             <EnumSelect
               key="backend"

--- a/src/index.css
+++ b/src/index.css
@@ -110,7 +110,7 @@ select{
   box-sizing: border-box;
 }
 
-.device {
+.group {
   background: #fff;
   border: 2px inset #999;
   float: left;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,10 @@ class CamillaConfig extends React.Component<any, any> {
         target_level: 1024,
         queuelimit: 100,
 
+        //Silence
+        silence_threshold: 0,
+        silence_timeout: 0,
+
         //Rate adjust
         enable_rate_adjust: false,
         adjust_period: 3,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,12 +25,35 @@ class CamillaConfig extends React.Component<any, any> {
     this.switchTab = this.switchTab.bind(this);
     this.state = {
       activetab: 0,
-      config: {
-        devices: this.getDevicesTemplate(),
-        filters: this.getFiltersTemplate(),
-        mixers: this.getMixersTemplate(),
-        pipeline: this.getPipelineTemplate(),
+      config: this.createDefaultConfig(),
+    };
+  }
+
+  private createDefaultConfig() {
+    return {
+      devices: {
+        samplerate: 48000,
+
+        //Buffers
+        chunksize: 1024,
+        target_level: 1024,
+        queuelimit: 100,
+
+        //Rate adjust
+        enable_rate_adjust: false,
+        adjust_period: 3,
+
+        //Resampler
+        enable_resampling: true,
+        resampler_type: "FastAsync",
+        capture_samplerate: 44100,
+
+        capture: {type: "Alsa", channels: 2, format: "S32LE", device: "hw:0"},
+        playback: {type: "Alsa", channels: 2, format: "S32LE", device: "hw:0"},
       },
+      filters: {},
+      mixers: {},
+      pipeline: [],
     };
   }
 
@@ -75,43 +98,6 @@ class CamillaConfig extends React.Component<any, any> {
     this.setState((prevState: any) => {
       return { config: config };
     });
-  }
-
-  getDevicesTemplate() {
-    return {
-      samplerate: 48000,
-      chunksize: 1024,
-      target_level: 1024,
-      adjust_period: 3,
-      queuelimit: 100,
-      enable_resampling: true,
-      enable_rate_adjust: false,
-      resampler_type: "FastAsync",
-      capture_samplerate: 44100,
-      capture: { type: "Alsa", channels: 2, format: "S32LE", device: "hw:0" },
-      playback: { type: "Alsa", channels: 2, format: "S32LE", device: "hw:0" },
-    };
-  }
-
-  getFiltersTemplate() {
-    return {
-      test1: {
-        type: "Biquad",
-        parameters: {
-          type: "Lowpass",
-          q: 0.7,
-          freq: 500,
-        },
-      },
-    };
-  }
-
-  getMixersTemplate() {
-    return {};
-  }
-
-  getPipelineTemplate() {
-    return [];
   }
 
   getFilterNames() {


### PR DESCRIPTION
Here is what I changed:
- grouped the options on the devices tab into categories (see screenshot)
    - the order and visibility of fields is now fixed and does not depend on occurrence in the default config json or config files
- added silence_threshold and silence_timeout to default config (before, they were invisible by default)
- refactored the creation of the default config into a single method and removed the lowpass filter from the default config (it is not obvious and degrades the sound, if you don't see and remove it)

![Devices](https://user-images.githubusercontent.com/7657699/104971071-e2ac5c80-59ed-11eb-97cc-491d4cb29f6c.png)
