### PR TITLE
Hide unneeded options for file/stdin inputs.

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -463,7 +463,7 @@ export class ParameterInput extends React.Component {
     },
     resampler_type: {
       type: "enum",
-      desc: "resampler type",
+      desc: "resampler_type",
       subtype: "resampler",
       tooltip: "Resampler type",
     },

--- a/src/devices.js
+++ b/src/devices.js
@@ -40,15 +40,12 @@ export class Devices extends React.Component {
   }
 
   handleCapture(params) {
-    this.setState((oldState) => {
+    this.setState((state) => {
       console.log("devices got:", params);
-      const newState = cloneDeep(oldState);
-      newState.config.capture = params;
-      if (hasFileCaptureDevice(oldState.config) !== hasFileCaptureDevice(newState.config))
-        newState.config.queuelimit = hasFileCaptureDevice(newState.config) ? 1 : 100;
-      console.log("devices new:", newState);
-      this.props.onChange(newState.config);
-      return newState;
+      state.config.capture = params;
+      console.log("devices new:", state);
+      this.props.onChange(state.config);
+      return state;
     });
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -291,6 +291,7 @@ select{
   width: 100%;
   float: left;
   display: flex;
+  align-items:center;
 }
 
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,7 +37,7 @@ class CamillaConfig extends React.Component<any, any> {
         //Buffers
         chunksize: 1024,
         target_level: 1024,
-        queuelimit: 100,
+        queuelimit: 4,
 
         //Silence
         silence_threshold: 0,

--- a/src/volumeslider.js
+++ b/src/volumeslider.js
@@ -23,12 +23,14 @@ export class VolumeSlider extends React.Component {
   render() {
     return (
       <div className="slidecontainer">
+        <span style={{width: '20%'}}>{this.state.value}dB</span>
         <input
+          style={{width: '80%'}}
           type="range"
-          min="-100"
+          min="-99"
           max="0"
           value={this.state.value}
-          class="slider"
+          className="slider"
           id="volume"
           onChange={this.handleChange}
         />


### PR DESCRIPTION
- When switching to file/stdin inputs, unneeded options (`target_level`, `enable_rate_adjust`, `adjust_period`) are hidden. When switching back, they are restored.
- `queuelimit` is changed to 1 when switching to file/stdin input and to 100 when switching to other inputs.
- Renamed option "resampler type" to "resampler_type" for consistency.