### PR TITLE
Hide options

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -463,7 +463,7 @@ export class ParameterInput extends React.Component {
     },
     resampler_type: {
       type: "enum",
-      desc: "resampler type",
+      desc: "resampler_type",
       subtype: "resampler",
       tooltip: "Resampler type",
     },

--- a/src/devices.js
+++ b/src/devices.js
@@ -40,15 +40,12 @@ export class Devices extends React.Component {
   }
 
   handleCapture(params) {
-    this.setState((oldState) => {
+    this.setState((state) => {
       console.log("devices got:", params);
-      const newState = cloneDeep(oldState);
-      newState.config.capture = params;
-      if (hasFileCaptureDevice(oldState.config) !== hasFileCaptureDevice(newState.config))
-        newState.config.queuelimit = hasFileCaptureDevice(newState.config) ? 1 : 100;
-      console.log("devices new:", newState);
-      this.props.onChange(newState.config);
-      return newState;
+      state.config.capture = params;
+      console.log("devices new:", state);
+      this.props.onChange(state.config);
+      return state;
     });
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,7 +37,7 @@ class CamillaConfig extends React.Component<any, any> {
         //Buffers
         chunksize: 1024,
         target_level: 1024,
-        queuelimit: 100,
+        queuelimit: 4,
 
         //Silence
         silence_threshold: 0,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,7 +28,7 @@ class CamillaConfig extends React.Component<any, any> {
       guiConfig: {},
       config: this.createDefaultConfig()
     };
-    window.fetch(FLASKURL + "/api/gui-config.json")
+    window.fetch(FLASKURL + "/api/guiconfig")
         .then(data => data.json())
         .then(json => { this.setState({guiConfig: json}); });
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,8 +25,12 @@ class CamillaConfig extends React.Component<any, any> {
     this.switchTab = this.switchTab.bind(this);
     this.state = {
       activetab: 0,
-      config: this.createDefaultConfig(),
+      guiConfig: {},
+      config: this.createDefaultConfig()
     };
+    window.fetch(FLASKURL + "/api/gui-config.json")
+        .then(data => data.json())
+        .then(json => { this.setState({guiConfig: json}); });
   }
 
   private createDefaultConfig() {
@@ -159,6 +163,7 @@ class CamillaConfig extends React.Component<any, any> {
             <TabPanel>
               <Devices
                 config={this.state.config.devices}
+                guiConfig={this.state.guiConfig}
                 onChange={this.handleDevices}
               />
             </TabPanel>


### PR DESCRIPTION
Note: The the first two commits are from https://github.com/HEnquist/camillagui/pull/12. Only the last commit is relevant to this PR.

The corresponding backend changes are in https://github.com/HEnquist/camillagui-backend/pull/14.
This adds the possibility to hide the following options from the `Devices` Tab:
- `samplerate` option
- `Silence` section
- `Capture Device` section
- `Playback Device` section
