### PR TITLE
"Rate adjust" section is now hidden for stdin/file/pulse audio playback devices

### DIFF
--- a/src/devices.js
+++ b/src/devices.js
@@ -103,7 +103,8 @@ function Samplerate(props) {
 }
 
 function RateAdjustOptions(props) {
-  if (hasFileCaptureDevice(props.config))
+  let isFileStdinOrPulseCaptureDevice = ["File", "Stdin", "Pulse"].includes(props.config.capture.type);
+  if (isFileStdinOrPulseCaptureDevice)
     return null;
   return <Group
       title="Rate adjust"
@@ -111,10 +112,6 @@ function RateAdjustOptions(props) {
       config={props.config}
       onChange={props.onChange}
   />;
-}
-
-function hasFileCaptureDevice(config) {
-  return ["File", "Stdin"].includes(config.capture.type);
 }
 
 function Group(props) {
@@ -133,7 +130,8 @@ function Group(props) {
 }
 
 function BufferOptions(props) {
-  const propertyNames = hasFileCaptureDevice(props.config) ?
+  let isFileOrStdinCaptureDevice = ["File", "Stdin"].includes(props.config.capture.type);
+  const propertyNames = isFileOrStdinCaptureDevice ?
       ['chunksize', 'queuelimit'] :
       ['chunksize', 'target_level', 'queuelimit'];
   return <Group

--- a/src/devices.js
+++ b/src/devices.js
@@ -103,12 +103,12 @@ function Samplerate(props) {
 }
 
 function RateAdjustOptions(props) {
-  let isFileStdinOrPulseCaptureDevice = ["File", "Stdin", "Pulse"].includes(props.config.capture.type);
-  if (isFileStdinOrPulseCaptureDevice)
+  let playbackDeviceIsOneOf = (types) => types.includes(props.config.playback.type);
+  if (playbackDeviceIsOneOf(["File", "Stdout", "Pulse"]))
     return null;
   return <Group
       title="Rate adjust"
-      propertyNames={['enable_rate_adjust', 'adjust_period']}
+      propertyNames={['enable_rate_adjust', 'adjust_period', 'target_level']}
       config={props.config}
       onChange={props.onChange}
   />;
@@ -130,13 +130,9 @@ function Group(props) {
 }
 
 function BufferOptions(props) {
-  let isFileOrStdinCaptureDevice = ["File", "Stdin"].includes(props.config.capture.type);
-  const propertyNames = isFileOrStdinCaptureDevice ?
-      ['chunksize', 'queuelimit'] :
-      ['chunksize', 'target_level', 'queuelimit'];
   return <Group
       title="Buffers"
-      propertyNames={propertyNames}
+      propertyNames={['chunksize', 'queuelimit']}
       config={props.config}
       onChange={props.onChange}
   />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,7 +40,6 @@ class CamillaConfig extends React.Component<any, any> {
 
         //Buffers
         chunksize: 1024,
-        target_level: 1024,
         queuelimit: 4,
 
         //Silence
@@ -50,6 +49,7 @@ class CamillaConfig extends React.Component<any, any> {
         //Rate adjust
         enable_rate_adjust: false,
         adjust_period: 3,
+        target_level: 1024,
 
         //Resampler
         enable_resampling: true,


### PR DESCRIPTION
According to the CamillaDSP documentation, rate adjust is not available for pulse audio capture devices,
so it is now also hidden from the GUI when a pulse capture device is selected.