### PR TITLE
Fixed "format" not being saved internally

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -138,7 +138,13 @@ export class EnumSelect extends React.Component {
 
   handleChange(event) {
     this.setState({ value: event.target.value });
-    this.props.onSelect(event.target.value);
+    if (this.props.desc === "format")
+      this.props.onSelect({
+        id: this.props.desc,
+        value: event.target.value
+      });
+    else
+      this.props.onSelect(event.target.value);
   }
 
   render() {

--- a/src/common.js
+++ b/src/common.js
@@ -139,6 +139,8 @@ export class EnumSelect extends React.Component {
   handleChange(event) {
     this.setState({ value: event.target.value });
     if (this.props.desc === "format")
+      // capture/playback/convolution format parameter cannot be changed without this hack
+      //TODO: fix this in a nicer way
       this.props.onSelect({
         id: this.props.desc,
         value: event.target.value


### PR DESCRIPTION
Fixed "format" not being saved internally for capture/playback devices and convolution filters.
This fixes #17.

The solution is pretty hacky, but I do not see a clean way to fix this.
When I fixed it for the `format` field, it broke all other `EnumSelect`s.
At least this points to the cause of the error, so it saves you some debugging time, if you want to fix it cleanly.