### PR TITLE
Replaced global FLASKURL with proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
         "awesome-typescript-loader": "^5.2.1",
         "chart.js": "^2.9.4",
         "d3": "^6.2.0",
+        "http-proxy-middleware": "^1.0.6",
         "immutable": "^4.0.0-rc.12",
-        "lodash": "^4.17.21",
         "lodash.clonedeep": "^4.5.0",
         "lodash.isequal": "^4.5.0",
         "rc-progress": "^3.1.1",
@@ -1742,6 +1742,14 @@
       "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
       "dependencies": {
         "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.5.tgz",
+      "integrity": "sha512-GNkDE7bTv6Sf8JbV2GksknKOsk7OznNYHSdrtvPJXO0qJ9odZig6IZKUi5RFGi6d1bf6dgIAe4uXi3DBc7069Q==",
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -7818,17 +7826,71 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
-      "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.6.tgz",
+      "integrity": "sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==",
       "dependencies": {
-        "http-proxy": "^1.17.0",
-        "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
-        "micromatch": "^3.1.10"
+        "@types/http-proxy": "^1.17.4",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.20",
+        "micromatch": "^4.0.2"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/micromatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "dependencies": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/http-signature": {
@@ -16390,6 +16452,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+      "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/is-absolute-url": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
@@ -18647,6 +18723,14 @@
       "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
       "requires": {
         "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/http-proxy": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.5.tgz",
+      "integrity": "sha512-GNkDE7bTv6Sf8JbV2GksknKOsk7OznNYHSdrtvPJXO0qJ9odZig6IZKUi5RFGi6d1bf6dgIAe4uXi3DBc7069Q==",
+      "requires": {
         "@types/node": "*"
       }
     },
@@ -23849,14 +23933,55 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
-      "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.6.tgz",
+      "integrity": "sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==",
       "requires": {
-        "http-proxy": "^1.17.0",
-        "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
-        "micromatch": "^3.1.10"
+        "@types/http-proxy": "^1.17.4",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.20",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "http-signature": {
@@ -30990,6 +31115,17 @@
                 "is-extglob": "^2.1.0"
               }
             }
+          }
+        },
+        "http-proxy-middleware": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+          "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+          "requires": {
+            "http-proxy": "^1.17.0",
+            "is-glob": "^4.0.0",
+            "lodash": "^4.17.11",
+            "micromatch": "^3.1.10"
           }
         },
         "is-absolute-url": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "awesome-typescript-loader": "^5.2.1",
     "chart.js": "^2.9.4",
     "d3": "^6.2.0",
+    "http-proxy-middleware": "^1.0.6",
     "immutable": "^4.0.0-rc.12",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0",

--- a/src/common-tsx.tsx
+++ b/src/common-tsx.tsx
@@ -3,7 +3,6 @@ import Icon from "@mdi/react"
 import Popup from "reactjs-popup"
 import {Scatter} from "react-chartjs-2"
 import {mdiChartBellCurveCumulative, mdiDelete, mdiPlusThick} from "@mdi/js";
-import {FLASKURL} from "./index";
 import 'reactjs-popup/dist/index.css';
 import cloneDeep from "lodash/cloneDeep";
 
@@ -61,7 +60,7 @@ export async function doUpload(
     }
     event.target.value = '' // this resets the upload field, so the same file can be uploaded twice in a row
     try {
-        await fetch(`${FLASKURL}/api/upload${type}s`, {
+        await fetch(`/api/upload${type}s`, {
             method: "POST",
             body: formData
         })

--- a/src/files.tsx
+++ b/src/files.tsx
@@ -1,6 +1,5 @@
 import React, {ChangeEvent, Component} from "react"
 import {Set} from "immutable"
-import {FLASKURL} from "./index"
 import {Box, CheckBox, doUpload, download, MdiButton, UploadButton} from "./common-tsx"
 import {mdiAlertCircle, mdiCheck, mdiContentSave, mdiDelete, mdiDownload, mdiRefresh, mdiUpload} from '@mdi/js'
 import {Config} from "./config";
@@ -94,7 +93,7 @@ class FileTable extends Component<
   }
 
   private update() {
-    fetch(`${FLASKURL}/api/stored${this.type}s`)
+    fetch(`/api/stored${this.type}s`)
       .then(response => response.json())
       .then(json => this.setState((prevState) => {
         let files = json as string[];
@@ -109,7 +108,7 @@ class FileTable extends Component<
     const del = window.confirm("Delete?\n" + this.state.selectedFiles.join('\n'))
     if (!del)
       return
-    await fetch(`${FLASKURL}/api/delete${this.type}s`, {
+    await fetch(`/api/delete${this.type}s`, {
       method: "POST",
       headers: { "Content-Type": "application/json", },
       body: JSON.stringify(this.state.selectedFiles),
@@ -119,7 +118,7 @@ class FileTable extends Component<
   }
 
   private async downloadAsZip() {
-    const response = await fetch(`${FLASKURL}/api/download${this.type}szip`, {
+    const response = await fetch(`/api/download${this.type}szip`, {
       method: "POST",
       headers: { "Content-Type": "application/json", },
       body: JSON.stringify(this.state.selectedFiles),
@@ -146,7 +145,7 @@ class FileTable extends Component<
 
   private async loadConfig(name: string) {
     try {
-      const response = await fetch(`${FLASKURL}/api/getconfigfile?name=${encodeURIComponent(name)}`)
+      const response = await fetch(`/api/getconfigfile?name=${encodeURIComponent(name)}`)
       if (!response.ok) {
         this.showErrorMessage(name, 'load', await response.text())
         return
@@ -175,7 +174,7 @@ class FileTable extends Component<
   private async saveConfig(name: string) {
     const { config, setActiveConfig } = this.props
     try {
-      const response = await fetch(`${FLASKURL}/api/saveconfigfile`, {
+      const response = await fetch(`/api/saveconfigfile`, {
         method: "POST",
         headers: { "Content-Type": "application/json", },
         body: JSON.stringify({filename: name, config: config}),
@@ -390,9 +389,10 @@ function FileDownloadButton(props: { type: string, filename: string, highlight: 
   return <a className={classNames}
             style={{width: 'max-content'}}
             data-tip={'Download '+filename}
+            download={filename}
             target="_blank"
             rel="noopener noreferrer"
-            href={`${FLASKURL}/${type}/${filename}`}>
+            href={`/${type}/${filename}`}>
     {filename}
   </a>
 }

--- a/src/filterstab.tsx
+++ b/src/filterstab.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import cloneDeep from "lodash/cloneDeep";
 import "./index.css";
-import {FLASKURL} from "./index";
 import {mdiAlertCircle, mdiChartBellCurveCumulative, mdiCheck, mdiFileSearch, mdiUpload} from '@mdi/js';
 import {
   Config,
@@ -114,7 +113,7 @@ export class FiltersTab extends React.Component<
   }
 
   private plotFilter(name: string) {
-    fetch(FLASKURL + "/api/evalfilter", {
+    fetch("/api/evalfilter", {
       method: "POST",
       headers: { "Content-Type": "application/json", },
       body: JSON.stringify({
@@ -134,7 +133,7 @@ export class FiltersTab extends React.Component<
   }
 
   private updateAvailableCoeffFiles() {
-    fetch(FLASKURL + "/api/storedcoeffs")
+    fetch("/api/storedcoeffs")
         .then(
             result => result.json()
                 .then(coeffFiles => this.setState({availableCoeffFiles: coeffFiles})),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,9 +18,6 @@ import {defaultGuiConfig, GuiConfig} from "./guiconfig";
 import {Update} from "./common-tsx";
 import cloneDeep from "lodash/cloneDeep";
 
-//export const FLASKURL = "http://127.0.0.1:5000"
-export const FLASKURL = ""
-
 class CamillaConfig extends React.Component<
   unknown,
   {
@@ -41,7 +38,7 @@ class CamillaConfig extends React.Component<
       guiConfig: defaultGuiConfig(),
       config: defaultConfig()
     }
-    fetch(FLASKURL + "/api/guiconfig")
+    fetch("/api/guiconfig")
         .then(data => data.json())
         .then(json => this.setState({guiConfig: json}))
   }

--- a/src/pipelinetab.tsx
+++ b/src/pipelinetab.tsx
@@ -1,7 +1,6 @@
 import React, {ReactNode} from "react"
 import "./index.css"
 import {PipelinePopup} from './pipelineplotter.js'
-import {FLASKURL} from "./index"
 import {
   AddButton,
   Box,
@@ -69,7 +68,7 @@ export class PipelineTab extends React.Component<{
       })
 
   plotFilterStep = (index: number) => {
-    fetch(FLASKURL + "/api/evalfilterstep", {
+    fetch("/api/evalfilterstep", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({index: index, config: this.props.config}),

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,8 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function (app) {
+    const forwardToBackend = createProxyMiddleware({target: 'http://localhost:5000', changeOrigin: true});
+    app.use('/api', forwardToBackend);
+    app.use('/config', forwardToBackend);
+    app.use('/coeff', forwardToBackend);
+};

--- a/src/sidepanel.tsx
+++ b/src/sidepanel.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import "./index.css";
 import isEqual from "lodash/isEqual";
-import {FLASKURL} from "./index";
 import camillalogo from "./camilladsp.svg";
 import {VuMeterGroup} from "./vumeter";
 import {VolumeSlider} from "./volumeslider";
@@ -28,7 +27,7 @@ class ConfigCheckMessage extends React.Component<
 
   private async get_config_errors(config: Config) {
     try {
-      const request = await fetch(FLASKURL + "/api/validateconfig", {
+      const request = await fetch("/api/validateconfig", {
         method: "POST",
         headers: {"Content-Type": "application/json"},
         body: JSON.stringify(config),
@@ -110,9 +109,9 @@ export class SidePanel extends React.Component<
     const intervalId = setInterval(this.timer, 500)
     this.setState({ clearTimer: () => {  clearInterval(intervalId) } })
     try {
-      const dsp_ver_req = await fetch(FLASKURL + "/api/version")
-      const pylib_ver_req = await fetch(FLASKURL + "/api/libraryversion")
-      const backend_ver_req = await fetch(FLASKURL + "/api/backendversion")
+      const dsp_ver_req = await fetch("/api/version")
+      const pylib_ver_req = await fetch("/api/libraryversion")
+      const backend_ver_req = await fetch("/api/backendversion")
       const dsp_ver = await dsp_ver_req.json()
       const pylib_ver = await pylib_ver_req.json()
       const backend_ver = await backend_ver_req.json()
@@ -130,7 +129,7 @@ export class SidePanel extends React.Component<
   }
 
   private async timer() {
-    const state_req = await fetch(FLASKURL + "/api/getparam/state")
+    const state_req = await fetch("/api/getparam/state")
     const processingstate = await state_req.text()
     let capture_rms: number[] = []
     let playback_rms: number[] = []
@@ -139,12 +138,12 @@ export class SidePanel extends React.Component<
     let bufferlevel: number | '' = ''
     let nbrclipped: number | '' = ''
     try {
-      const capt_rms_req = await fetch(FLASKURL + "/api/getlistparam/capturesignalrms")
-      const pb_rms_req = await fetch(FLASKURL + "/api/getlistparam/playbacksignalrms")
-      const capturerate_req = await fetch(FLASKURL + "/api/getparam/capturerate")
-      const rateadjust_req = await fetch(FLASKURL + "/api/getparam/rateadjust")
-      const bufferlevel_req = await fetch(FLASKURL + "/api/getparam/bufferlevel")
-      const nbrclipped_req = await fetch(FLASKURL + "/api/getparam/clippedsamples")
+      const capt_rms_req = await fetch("/api/getlistparam/capturesignalrms")
+      const pb_rms_req = await fetch("/api/getlistparam/playbacksignalrms")
+      const capturerate_req = await fetch("/api/getparam/capturerate")
+      const rateadjust_req = await fetch("/api/getparam/rateadjust")
+      const bufferlevel_req = await fetch("/api/getparam/bufferlevel")
+      const nbrclipped_req = await fetch("/api/getparam/clippedsamples")
       capture_rms = await capt_rms_req.json()
       playback_rms = await pb_rms_req.json()
       capturerate = parseInt(await capturerate_req.text())
@@ -168,7 +167,7 @@ export class SidePanel extends React.Component<
   }
 
   private async fetchConfig() {
-    const conf_req = await fetch(FLASKURL + "/api/getconfig")
+    const conf_req = await fetch("/api/getconfig")
     const config = await conf_req.json()
     if (config) {
       this.setState({msg: "OK"})
@@ -179,7 +178,7 @@ export class SidePanel extends React.Component<
   }
 
   private async setVolume(value: string) {
-    const vol_req = await fetch(FLASKURL + "/api/setparam/volume", {
+    const vol_req = await fetch("/api/setparam/volume", {
       method: "POST",
       headers: {"Content-Type": "text/plain; charset=us-ascii"},
       body: value,
@@ -189,7 +188,7 @@ export class SidePanel extends React.Component<
   }
 
   private async applyConfig() {
-    const conf_req = await fetch(FLASKURL + "/api/setconfig", {
+    const conf_req = await fetch("/api/setconfig", {
       method: "POST",
       headers: {"Content-Type": "application/json"},
       body: JSON.stringify(this.props.config),
@@ -199,7 +198,7 @@ export class SidePanel extends React.Component<
   }
 
   async loadCurrentConfig() {
-    const conf_req = await fetch(FLASKURL + "/api/getactiveconfigfile", {
+    const conf_req = await fetch("/api/getactiveconfigfile", {
       method: "GET",
       headers: {"Content-Type": "text/html"},
       cache: "no-cache",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": [
     "./src/"


### PR DESCRIPTION
I removed the global FLASKURL. During development, the forwarding to the camillagui backend is now done by a proxy via setupProxy.js (see https://create-react-app.dev/docs/proxying-api-requests-in-development/#configuring-the-proxy-manually).
The release build is not impacted by this.