### PR TITLE
Plot in filters tab

### DIFF
--- a/src/filterstab.tsx
+++ b/src/filterstab.tsx
@@ -226,6 +226,9 @@ interface FilterViewState {
   showDefaults: boolean
 }
 
+const inlineFilterPlot = true
+// const inlineFilterPlot = false
+
 class FilterView extends React.Component<FilterViewProps, FilterViewState> {
 
   constructor(props: any) {
@@ -291,6 +294,8 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
   }
 
   componentDidUpdate(prevProps: Readonly<FilterViewProps>, prevState: Readonly<FilterViewState>, snapshot?: any) {
+    if (!inlineFilterPlot)
+      return
     const prevFilter = prevProps.filter
     const currentFilter = this.props.filter
     if (prevFilter.type !== currentFilter.type || !isEqual(prevFilter.parameters, currentFilter.parameters))
@@ -379,7 +384,7 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
           onClose={() => this.setState({popupOpen: false})}
           onSelect={this.pickFilterFile}
       />
-      {this.state.data ?
+      {inlineFilterPlot && this.state.data ?
           <Chart data={this.state.data} onChange={optionName => this.plotFilter()}/>
           : <div/>}
     </Box>

--- a/src/filterstab.tsx
+++ b/src/filterstab.tsx
@@ -194,6 +194,8 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
     this.pickFilterFile = this.pickFilterFile.bind(this)
     this.updateDefaults = this.updateDefaults.bind(this)
     this.updateFilterParamsWithDefaults = this.updateFilterParamsWithDefaults.bind(this)
+    this.toggleFilterPlot = this.toggleFilterPlot.bind(this)
+    this.plotFilterInitially = this.plotFilterInitially.bind(this)
     this.plotFilter = this.plotFilter.bind(this)
     this.state = {
       filterFilePopupOpen: false,
@@ -264,6 +266,21 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
     }
   }
 
+  private toggleFilterPlot() {
+    const showFilterPlot = !this.state.showFilterPlot
+    this.setState({showFilterPlot})
+    if (showFilterPlot)
+      this.plotFilter()
+    else
+      this.setState({data: undefined})
+  }
+
+  private plotFilterInitially(file: string) {
+    const options = this.state.data!!.options
+    const current = options.length === 0 ? undefined : options.filter(o => o.name === file)[0]
+    this.plotFilter(current?.samplerate, current?.channels)
+  }
+
   private plotFilter(samplerate?: number, channels?: number) {
     fetch("/api/evalfilter", {
       method: "POST",
@@ -311,14 +328,7 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
           <MdiButton
               icon={mdiChartBellCurveCumulative}
               tooltip="Plot frequency response of this filter"
-              onClick={() => {
-                const showFilterPlot = !this.state.showFilterPlot
-                this.setState({showFilterPlot})
-                if (showFilterPlot)
-                  this.plotFilter()
-                else
-                  this.setState({data: undefined})
-              }}/>
+              onClick={this.toggleFilterPlot}/>
           }
           {isConvolutionFileFilter(filter) &&
           <MdiButton
@@ -357,14 +367,7 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
           onSelect={this.pickFilterFile}
       />
       {this.state.showFilterPlot && this.state.data ?
-          <Chart
-              data={this.state.data}
-              onChange={file => {
-                const options = this.state.data!!.options
-                const current = options.length === 0 ? undefined : options.filter(o => o.name === file)[0]
-                this.plotFilter(current?.samplerate, current?.channels)
-              }}
-          />
+          <Chart data={this.state.data} onChange={this.plotFilterInitially}/>
           : null}
     </Box>
   }

--- a/src/filterstab.tsx
+++ b/src/filterstab.tsx
@@ -334,7 +334,7 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
           <MdiButton
               icon={mdiFileSearch}
               tooltip="Pick filter file"
-              onClick={() => this.setState({showFilterPlot: true})}/>
+              onClick={() => this.setState({filterFilePopupOpen: true})}/>
           }
           <DeleteButton tooltip={"Delete this filter"} onClick={this.props.remove}/>
         </div>

--- a/src/utilities/ui-components.tsx
+++ b/src/utilities/ui-components.tsx
@@ -568,11 +568,22 @@ export function ChartPopup(props: {
     onChange: (item: string) => void
     onClose: () => void
 }){
+    return <Popup open={props.open} onClose={props.onClose}>
+        <CloseButton onClick={props.onClose}/>
+        <h3 style={{textAlign: 'center'}}>{props.data.name}</h3>
+        <Chart onChange={props.onChange} data={props.data}/>
+    </Popup>
+}
+
+export function Chart(props: {
+    data: ChartData
+    onChange: (item: string) => void
+}) {
+    let data: any = {labels: [props.data.name], datasets: []}
     function make_pointlist(xvect: number[], yvect: number[], scaling_x: number, scaling_y: number) {
         return xvect.map((x, idx) => ({x: scaling_x * x, y: scaling_y * yvect[idx]}))
     }
 
-    let data: any = {labels: [props.data.name], datasets: []}
     let x_time = false
     let x_freq = false
     let y_phase = false
@@ -771,7 +782,6 @@ export function ChartPopup(props: {
             }
         )
     }
-
     function sortBySamplerateAndChannels(a: FilterOption, b: FilterOption) {
         if (a.samplerate !== b.samplerate && a.samplerate !== undefined && b.samplerate !== undefined)
             return a.samplerate - b.samplerate
@@ -779,20 +789,18 @@ export function ChartPopup(props: {
             return a.channels - b.channels
         return 0
     }
-
     const sampleRateOptions = props.data.options.sort(sortBySamplerateAndChannels)
-        .map(option => {
-                const selected = (option.samplerate === undefined || option.samplerate === props.data.samplerate)
-                    && (option.channels === undefined || option.channels === props.data.channels)
-                return <option key={option.name} selected={selected}>{option.name}</option>
-            }
+        .map(option =>
+            <option key={option.name}>{option.name}</option>
         )
-
-    return <Popup open={props.open} onClose={props.onClose}>
-        <CloseButton onClick={props.onClose}/>
-        <h3 style={{textAlign: 'center'}}>{props.data.name}</h3>
+    const selected = props.data.options.find(option =>
+        (option.samplerate === undefined || option.samplerate === props.data.samplerate)
+        && (option.channels === undefined || option.channels === props.data.channels)
+    )?.name
+    return <>
         <div style={{textAlign: 'center'}}>
             {props.data.options.length > 0 && <select
+                value={selected}
                 data-tip="Select filter file"
                 onChange={e => props.onChange(e.target.value)}
             >
@@ -800,8 +808,7 @@ export function ChartPopup(props: {
             </select>}
         </div>
         <Scatter data={data} options={options}/>
-    </Popup>
-
+    </>
 }
 
 export function ListSelectPopup(props: {

--- a/src/utilities/ui-components.tsx
+++ b/src/utilities/ui-components.tsx
@@ -544,10 +544,6 @@ export function delayedExecutor(delay: number): (action: Action) => void {
     }
 }
 
-export interface ChartPopupData {
-
-}
-
 export interface ChartData {
     name: string
     samplerate?: number

--- a/src/utilities/ui-components.tsx
+++ b/src/utilities/ui-components.tsx
@@ -544,6 +544,10 @@ export function delayedExecutor(delay: number): (action: Action) => void {
     }
 }
 
+export interface ChartPopupData {
+
+}
+
 export interface ChartData {
     name: string
     samplerate?: number


### PR DESCRIPTION
@HEnquist I am currently playing around with having the filter plot directly in the filters tab.
Unfortunately, the performance when changing filter values is horrible and I don't know, what to do about it - there are no requests going to the server and I did not find anything suspicious during profiling.
E.g. when you add a Biquad/Lowpass and change the frequency from 10Hz to 10000Hz by typing three zeroes, there is a noticeable delay during typing. The same happens, when you delete three zeroes to change it back to 10Hz.
If you shut down the backend, the plots aren't shown and the performance issue goes away.

What do you think of the current solution?
Does it take too much space?
Is the performance tolerable?
Do you have any recommendations?