### PR TITLE
Introduced ErrorBoundaries

### DIFF
--- a/src/compactview.tsx
+++ b/src/compactview.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import {VolumeBox} from "./sidepanel/volumebox"
-import {MdiButton} from "./utilities/ui-components"
+import {ErrorBoundary, MdiButton} from "./utilities/ui-components"
 import {mdiImageSizeSelectSmall} from "@mdi/js"
 import {Config} from "./camilladsp/config"
 import {defaultStatus} from "./camilladsp/status"
@@ -38,14 +38,16 @@ export function CompactView(props: {
   const {currentConfigName, config, setConfig, updateConfig, disableCompactView, guiConfig} = props
   return <div className="tabpanel" style={{margin: 'auto'}}>
     <DisableCompactViewButton disableCompactView={disableCompactView}/>
-    <VolumeBox
-      vuMeterStatus={defaultStatus()}
-      setMessage={() => {}}
-      inputLabels={null}
-      outputLabels={null}
-      guiConfig={guiConfig}/>
-    <ShortcutSections sections={guiConfig.custom_shortcuts} config={config} updateConfig={updateConfig}/>
-    <QuickConfigSwitch setConfig={setConfig} currentConfigName={currentConfigName}/>
+    <ErrorBoundary>
+      <VolumeBox
+        vuMeterStatus={defaultStatus()}
+        setMessage={() => {}}
+        inputLabels={null}
+        outputLabels={null}
+        guiConfig={guiConfig}/>
+      <ShortcutSections sections={guiConfig.custom_shortcuts} config={config} updateConfig={updateConfig}/>
+      <QuickConfigSwitch setConfig={setConfig} currentConfigName={currentConfigName}/>
+    </ErrorBoundary>
   </div>
 }
 

--- a/src/filestab.tsx
+++ b/src/filestab.tsx
@@ -1,5 +1,15 @@
 import React, {Component} from "react"
-import {Box, Button, MdiButton, UploadButton, fileDateSort, fileNameSort, fileTitleSort, fileValidSort} from "./utilities/ui-components"
+import {
+  Box,
+  Button,
+  MdiButton,
+  UploadButton,
+  fileDateSort,
+  fileNameSort,
+  fileTitleSort,
+  fileValidSort,
+  ErrorBoundary
+} from "./utilities/ui-components"
 import {GuiConfig} from "./guiconfig"
 import {
   mdiAlertCircle,
@@ -40,20 +50,25 @@ export function Files(props: {
   updateConfig: (update: Update<Config>) => void
   saveNotify: () => void
 }) {
-  return <div className="tabcontainer"><div className="wide-tabpanel" style={{ width: '900px' }}>
-    <NewConfig currentConfig={props.config}
-               setCurrentConfig={props.setCurrentConfig}
-               updateConfig={props.updateConfig}/>
-    <FileTable title='Configs'
-               type="config"
-               currentConfigFile={props.currentConfigFile}
-               config={props.config}
-               setCurrentConfig={props.setCurrentConfig}
-               setCurrentConfigFileName={props.setCurrentConfigFileName}
-               saveNotify={props.saveNotify}
-               canUpdateActiveConfig={props.guiConfig.can_update_active_config}/>
-    <FileTable title='Filters' type="coeff"/>
-  </div><div className="tabspacer"></div></div>
+  return <ErrorBoundary>
+    <div className="tabcontainer">
+      <div className="wide-tabpanel" style={{ width: '900px' }}>
+        <NewConfig currentConfig={props.config}
+                   setCurrentConfig={props.setCurrentConfig}
+                   updateConfig={props.updateConfig}/>
+        <FileTable title='Configs'
+                   type="config"
+                   currentConfigFile={props.currentConfigFile}
+                   config={props.config}
+                   setCurrentConfig={props.setCurrentConfig}
+                   setCurrentConfigFileName={props.setCurrentConfigFileName}
+                   saveNotify={props.saveNotify}
+                   canUpdateActiveConfig={props.guiConfig.can_update_active_config}/>
+        <FileTable title='Filters' type="coeff"/>
+      </div>
+      <div className="tabspacer"/>
+    </div>
+  </ErrorBoundary>
 }
 
 interface FileTableProps {

--- a/src/filterstab.tsx
+++ b/src/filterstab.tsx
@@ -37,9 +37,10 @@ import {
   OptionalIntOption,
   ParsedInput,
   TextOption,
-  UploadButton
+  UploadButton,
+  ErrorBoundary
 } from "./utilities/ui-components"
-import { ErrorsForPath, errorsForSubpath } from "./utilities/errors"
+import {Errors} from "./utilities/errors"
 import { modifiedCopyOf, Update } from "./utilities/common"
 import { isEqual } from "lodash"
 import { Chart, ChartData } from "./utilities/chart"
@@ -57,7 +58,7 @@ export class FiltersTab extends React.Component<
     channels: Promise<number>
     coeffDir: string
     updateConfig: (update: Update<Config>) => void
-    errors: ErrorsForPath
+    errors: Errors
   },
   {
     filterKeys: { [name: string]: number }
@@ -159,44 +160,49 @@ export class FiltersTab extends React.Component<
 
   render() {
     let { config, errors } = this.props
-    return <div>
-      <div className="horizontally-spaced-content" style={{ width: '700px' }}>
-        <EnumOption
-          value={this.state.sortBy}
-          options={FilterSortKeys}
-          desc="Sort filters by"
-          tooltip="Property used to sort filters"
-          onChange={this.changeSortBy} />
-        <BoolOption
-          value={this.state.sortReverse}
-          desc="Reverse order"
-          tooltip="Reverse display order"
-          onChange={this.changeSortOrder} />
+    return <ErrorBoundary errorMessage={errors.asText()}>
+      <div>
+        <div className="horizontally-spaced-content" style={{ width: '700px' }}>
+          <EnumOption
+            value={this.state.sortBy}
+            options={FilterSortKeys}
+            desc="Sort filters by"
+            tooltip="Property used to sort filters"
+            onChange={this.changeSortBy} />
+          <BoolOption
+            value={this.state.sortReverse}
+            desc="Reverse order"
+            tooltip="Reverse display order"
+            onChange={this.changeSortOrder} />
+        </div>
+        <div className="tabcontainer">
+          <div className="tabpanel-with-header" style={{ width: '700px'}}>
+            <ErrorMessage message={errors.rootMessage()} />
+            {this.filterNames()
+              .map(name =>
+                <FilterView
+                  key={this.state.filterKeys[name]}
+                  name={name}
+                  // @ts-ignore
+                  filter={config.filters[name]}
+                  errors={errors.forSubpath(name)}
+                  availableCoeffFiles={this.state.availableCoeffFiles}
+                  updateFilter={update => this.updateFilter(name, update)}
+                  rename={newName => this.renameFilter(name, newName)}
+                  isFreeFilterName={this.isFreeFilterName}
+                  remove={() => this.removeFilter(name)}
+                  updateAvailableCoeffFiles={this.updateAvailableCoeffFiles}
+                  coeffDir={this.props.coeffDir}
+                  samplerate={this.props.samplerate}
+                  channels={this.props.channels}
+                />
+              )}
+            <AddButton tooltip="Add a new filter" onClick={this.addFilter} />
+          </div>
+          <div className="tabspacer"/>
+        </div>
       </div>
-      <div className="tabcontainer">
-      <div className="tabpanel-with-header" style={{ width: '700px'}}>
-        <ErrorMessage message={errors({ path: [] })} />
-        {this.filterNames()
-          .map(name =>
-            <FilterView
-              key={this.state.filterKeys[name]}
-              name={name}
-              // @ts-ignore
-              filter={config.filters[name]}
-              errors={errorsForSubpath(errors, name)}
-              availableCoeffFiles={this.state.availableCoeffFiles}
-              updateFilter={update => this.updateFilter(name, update)}
-              rename={newName => this.renameFilter(name, newName)}
-              isFreeFilterName={this.isFreeFilterName}
-              remove={() => this.removeFilter(name)}
-              updateAvailableCoeffFiles={this.updateAvailableCoeffFiles}
-              coeffDir={this.props.coeffDir}
-              samplerate={this.props.samplerate}
-              channels={this.props.channels}
-            />
-          )}
-        <AddButton tooltip="Add a new filter" onClick={this.addFilter} />
-      </div><div className="tabspacer"></div></div></div>
+    </ErrorBoundary>
   }
 }
 
@@ -219,7 +225,7 @@ interface FilterDefaults {
 interface FilterViewProps {
   name: string
   filter: Filter
-  errors: ErrorsForPath
+  errors: Errors
   availableCoeffFiles: FileInfo[]
   updateFilter: (update: Update<Filter>) => void
   rename: (newName: string) => void
@@ -497,7 +503,7 @@ const hiddenParameters = ['skip_bytes_lines', 'read_bytes_lines']
 
 class FilterParams extends React.Component<{
   filter: Filter
-  errors: ErrorsForPath
+  errors: Errors
   updateFilter: (update: Update<Filter>) => void
   availableCoeffFiles: FileInfo[]
   coeffDir: string
@@ -596,10 +602,10 @@ class FilterParams extends React.Component<{
     const defaults = DefaultFilterParameters[filter.type]
     const subtypeOptions = defaults ? Object.keys(defaults) : []
     return <div style={{ width: '100%', textAlign: 'right' }}>
-      <ErrorMessage message={errors({ path: [] })} />
+      <ErrorMessage message={errors.rootMessage()} />
       <EnumOption
         value={filter.type}
-        error={errors({ path: ['type'] })}
+        error={errors.messageFor('type')}
         options={Object.keys(DefaultFilterParameters)}
         desc="type"
         tooltip="Filter type"
@@ -607,14 +613,14 @@ class FilterParams extends React.Component<{
       {subtypeOptions[0] !== 'Default' &&
         <EnumOption
           value={filter.parameters.type}
-          error={errors({ path: ['parameters', 'type'] })}
+          error={errors.messageFor('parameters', 'type')}
           options={subtypeOptions}
           desc="subtype"
           tooltip="Filter subtype"
           onChange={this.onSubtypeChange} />
       }
-      <ErrorMessage message={errors({ path: ['parameters'] })} />
-      {this.renderFilterParams(filter.parameters, errorsForSubpath(errors, 'parameters'))}
+      <ErrorMessage message={errors.messageFor('parameters')} />
+      {this.renderFilterParams(filter.parameters, errors.forSubpath('parameters'))}
       {isConvolutionFileFilter(this.props.filter) && !this.props.showDefaults && (this.hasHiddenDefaultValue()) &&
         <Button text="..." onClick={() => this.props.setShowDefaults()} />
       }
@@ -648,7 +654,7 @@ class FilterParams extends React.Component<{
     </div>
   }
 
-  private renderFilterParams(parameters: { [p: string]: any }, errors: ErrorsForPath) {
+  private renderFilterParams(parameters: { [p: string]: any }, errors: Errors) {
     return Object.keys(parameters).map(parameter => {
       if (parameter === 'type') // 'type' is already rendered by parent component
         return null
@@ -660,7 +666,7 @@ class FilterParams extends React.Component<{
       const commonProps = {
         key: parameter,
         value: parameters[parameter],
-        error: errors({ path: [parameter] }),
+        error: errors.messageFor(parameter),
         desc: info.desc,
         tooltip: info.tooltip,
         //onChange: (value: any) => this.timer(() => this.props.updateFilter(filter => filter.parameters[parameter] = value))

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ import {ProcessorsTab} from "./processorstab"
 import {PipelineTab} from "./pipeline/pipelinetab"
 import {TitleTab} from "./titletab"
 import {Shortcuts} from "./shortcuts"
-import {ErrorsForPath, errorsForSubpath, noErrors} from "./utilities/errors"
+import {Errors, NoErrors} from "./utilities/errors"
 import {Tab, TabList, TabPanel, Tabs} from "react-tabs"
 import {Tooltip} from 'react-tooltip'
 import {Files} from "./filestab"
@@ -37,7 +37,7 @@ class CamillaConfig extends React.Component<
     currentConfigFile?: string
     guiConfig: GuiConfig
     undoRedo: UndoRedo<Config>
-    errors: ErrorsForPath
+    errors: Errors
     compactView: boolean
     message: string
     unsavedChanges: boolean
@@ -64,7 +64,7 @@ class CamillaConfig extends React.Component<
       activetab: 1,
       guiConfig: defaultGuiConfig(),
       undoRedo: new UndoRedo(defaultConfig()),
-      errors: noErrors,
+      errors: NoErrors,
       compactView: isCompactViewEnabled(),
       message: '',
       unsavedChanges: false,
@@ -300,11 +300,11 @@ class CamillaConfig extends React.Component<
                 enabled={undoRedo.canRedo()}/>
           </Tab>
           <Tab>Title</Tab>
-          <Tab>Devices {errors({path: ['devices'], includeChildren: true}) && <ErrorIcon/>}</Tab>
-          <Tab>Filters {errors({path: ['filters'], includeChildren: true}) && <ErrorIcon/>}</Tab>
-          <Tab>Mixers {errors({path: ['mixers'], includeChildren: true}) && <ErrorIcon/>}</Tab>
-          <Tab>Processors {errors({path: ['processors'], includeChildren: true}) && <ErrorIcon/>}</Tab>
-          <Tab>Pipeline {errors({path: ['pipeline'], includeChildren: true}) && <ErrorIcon/>}</Tab>
+          <Tab>Devices {errors.hasErrorsFor('devices') && <ErrorIcon/>}</Tab>
+          <Tab>Filters {errors.hasErrorsFor('filters') && <ErrorIcon/>}</Tab>
+          <Tab>Mixers {errors.hasErrorsFor('mixers') && <ErrorIcon/>}</Tab>
+          <Tab>Processors {errors.hasErrorsFor('processors') && <ErrorIcon/>}</Tab>
+          <Tab>Pipeline {errors.hasErrorsFor('pipeline') && <ErrorIcon/>}</Tab>
           <Tab>Files</Tab>
           <Tab>Shortcuts</Tab>
         </TabList>
@@ -320,7 +320,7 @@ class CamillaConfig extends React.Component<
               devices={config.devices}
               guiConfig={this.state.guiConfig}
               updateConfig={this.updateConfig}
-              errors={errorsForSubpath(errors, 'devices')}
+              errors={errors.forSubpath('devices')}
           />
         </TabPanel>
         <TabPanel>
@@ -330,28 +330,28 @@ class CamillaConfig extends React.Component<
               channels={getCaptureChannelCount(config)}
               coeffDir={this.state.guiConfig.coeff_dir}
               updateConfig={this.updateConfig}
-              errors={errorsForSubpath(errors, 'filters')}
+              errors={errors.forSubpath('filters')}
           />
         </TabPanel>
         <TabPanel>
           <MixersTab
               config={config}
               updateConfig={this.updateConfig}
-              errors={errorsForSubpath(errors, 'mixers')}
+              errors={errors.forSubpath('mixers')}
           />
         </TabPanel>
         <TabPanel>
           <ProcessorsTab
               config={config}
               updateConfig={this.updateConfig}
-              errors={errorsForSubpath(errors, 'processors')}
+              errors={errors.forSubpath('processors')}
           />
         </TabPanel>
         <TabPanel>
           <PipelineTab
               config={config}
               updateConfig={this.updateConfig}
-              errors={errorsForSubpath(errors, 'pipeline')}
+              errors={errors.forSubpath('pipeline')}
           />
         </TabPanel>
         <TabPanel>

--- a/src/shortcuts.tsx
+++ b/src/shortcuts.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import {useEffect, useState} from "react"
-import {Box, Button, MdiIcon} from "./utilities/ui-components"
+import {Box, Button, ErrorBoundary, MdiIcon} from "./utilities/ui-components"
 import {mdiHelpCircleOutline, mdiAlert} from "@mdi/js"
 import {loadConfigJson, loadFilenames} from "./utilities/files"
 import {Config} from "./camilladsp/config"
@@ -17,10 +17,15 @@ export function Shortcuts(props: {
 })
 {
     const {currentConfigName, config, setConfig, updateConfig, shortcutSections} = props
-    return <div className="tabcontainer"><div className="tabpanel">
-        <ShortcutSections sections={shortcutSections} config={config} updateConfig={updateConfig}/>
-        <QuickConfigSwitch setConfig={setConfig} currentConfigName={currentConfigName}/>
-    </div><div className="tabspacer"></div></div>
+    return <ErrorBoundary>
+      <div className="tabcontainer">
+        <div className="tabpanel">
+          <ShortcutSections sections={shortcutSections} config={config} updateConfig={updateConfig}/>
+          <QuickConfigSwitch setConfig={setConfig} currentConfigName={currentConfigName}/>
+        </div>
+        <div className="tabspacer"/>
+      </div>
+    </ErrorBoundary>
 }
 
 export function ShortcutSections(props: {

--- a/src/sidepanel/configcheckmessage.tsx
+++ b/src/sidepanel/configcheckmessage.tsx
@@ -1,12 +1,12 @@
 import React from "react"
 import {Config} from "../camilladsp/config"
-import {ErrorsForPath, errorsOf, noErrors} from "../utilities/errors"
+import {Errors, NoErrors} from "../utilities/errors"
 import {delayedExecutor} from "../utilities/ui-components"
 import isEqual from "lodash/isEqual"
 
 export class Configcheckmessage extends React.Component<{
   config: Config,
-  setErrors: (errors: ErrorsForPath) => void
+  setErrors: (errors: Errors) => void
 },
     { message: string }> {
 
@@ -35,17 +35,17 @@ export class Configcheckmessage extends React.Component<{
       if (request.ok) {
         const message = await request.text()
         this.setState({message: message})
-        this.props.setErrors(noErrors)
+        this.props.setErrors(NoErrors)
       } else {
         const json = await request.json()
-        const errors = errorsOf(json)
-        const globalErrors = errors({path: []})
+        const errors = new Errors(json)
+        const globalErrors = errors.rootMessage()
         this.setState({message: 'Config has errors' + (globalErrors ? (':\n' + globalErrors) : '')})
         this.props.setErrors(errors)
       }
     } catch (err) {
       this.setState({message: 'Validation failed'})
-      this.props.setErrors(noErrors)
+      this.props.setErrors(NoErrors)
     }
   }
 

--- a/src/titletab.tsx
+++ b/src/titletab.tsx
@@ -1,23 +1,27 @@
 import React from "react"
 import "./index.css"
-import { TextInput, MultilineTextInput, Box } from "./utilities/ui-components"
+import {TextInput, MultilineTextInput, Box, ErrorBoundary} from "./utilities/ui-components"
 import { Config } from "./camilladsp/config"
 import {Update} from "./utilities/common"
 
 
-
 export function TitleTab(props: {
-    config: Config,
-    updateConfig: (update: Update<Config>) => void
-  }) {
-    return <div className="tabcontainer"><div className="tabpanel" style={{width: '700px'}}>
-      <Title
-          config={props.config}
-          onChange={props.updateConfig}/>
-        <Description
-          config={props.config}
-          onChange={props.updateConfig}/>
-    </div><div className="tabspacer"></div></div>
+  config: Config,
+  updateConfig: (update: Update<Config>) => void
+}) {
+    return <ErrorBoundary>
+      <div className="tabcontainer">
+        <div className="tabpanel" style={{width: '700px'}}>
+          <Title
+              config={props.config}
+              onChange={props.updateConfig}/>
+          <Description
+              config={props.config}
+              onChange={props.updateConfig}/>
+        </div>
+        <div className="tabspacer"/>
+      </div>
+    </ErrorBoundary>
   }
 
 function Title(props: {

--- a/src/utilities/errors.test.ts
+++ b/src/utilities/errors.test.ts
@@ -1,0 +1,127 @@
+import {Errors} from './errors'
+
+describe('hasErrors()', () => {
+
+  test('false for no errors', () => {
+    expect(new Errors().hasErrors())
+        .toBe(false)
+  })
+
+  test('true for errors', () => {
+    expect(new Errors([[[], '']]).hasErrors())
+        .toBe(true)
+  })
+
+})
+
+describe('hasErrorsFor(path)', () => {
+
+  test('false for no errors', () => {
+    expect(new Errors().hasErrorsFor('path'))
+        .toBe(false)
+  })
+
+  test('true for errors', () => {
+    expect(new Errors([[['path'], 'message']]).hasErrorsFor('path'))
+        .toBe(true)
+  })
+
+})
+
+describe('rootMessage()', () => {
+
+  test('rootMessage() is undefined, when there are no errors', () => {
+    expect(new Errors().rootMessage())
+        .toBe(undefined)
+  })
+
+  test('rootMessage() contains root error only', () => {
+    const errors = new Errors([
+      [[], 'root error'],
+      [['irrelevant'], 'irrelevant error'],
+      [[0], 'another irrelevant error']
+    ])
+    expect(errors.rootMessage())
+        .toEqual('root error')
+  })
+
+  test('rootMessage() joins two errors', () => {
+    const errors = new Errors([
+      [[], 'error1'],
+      [[], 'error2']
+    ])
+    expect(errors.rootMessage())
+        .toEqual("error1\nerror2")
+  })
+
+})
+
+describe('messageFor(path)', () => {
+
+  test('messageFor(path) is undefined, when there are no errors', () => {
+    expect(new Errors().messageFor('path'))
+        .toBe(undefined)
+  })
+
+  test('messageFor(path) contains only message for path', () => {
+    const errors = new Errors([
+        [[], 'parent message'],
+        [['path'], 'message'],
+        [['path', 'sub'], 'child message']
+    ])
+    expect(errors.messageFor('path'))
+        .toBe('message')
+  })
+})
+
+describe('asText()', () => {
+
+  test('asText() is empty string, when there are no errors', () => {
+    expect(new Errors().asText())
+        .toBe('')
+  })
+
+
+  test('asText() contains all errors including their paths', () => {
+    const errors = new Errors([
+      [[], 'root error'],
+      [['sub'], 'sub error'],
+      [['sub', 1], 'sub 1 error'],
+      [['sub', 2], 'sub 2 error']
+    ])
+    expect(errors.asText())
+        .toBe(
+            'root error\n' +
+            'sub: sub error\n' +
+            'sub|1: sub 1 error\n' +
+            'sub|2: sub 2 error'
+        )
+  })
+
+})
+
+describe('forSubpath()', () => {
+
+  const errors = new Errors([
+    [[], 'root error'],
+    [['sub'], 'sub error'],
+    [['sub', 1], 'sub 1 error'],
+    [['sub', 2], 'sub 2 error']
+  ])
+
+  test('simple subpath', () => {
+    expect(errors.forSubpath('sub').asText())
+        .toEqual(
+            'sub error\n' +
+            '1: sub 1 error\n' +
+            '2: sub 2 error'
+        )
+  })
+
+  test('nested subpath', () => {
+    expect(errors.forSubpath('sub', 1).asText())
+        .toEqual('sub 1 error')
+  })
+
+})
+

--- a/src/utilities/ui-components.tsx
+++ b/src/utilities/ui-components.tsx
@@ -1,13 +1,13 @@
-import React, { ChangeEvent, CSSProperties, ReactNode, useEffect, useRef, useState } from "react"
+import React, {ChangeEvent, CSSProperties, ErrorInfo, ReactNode, useEffect, useRef, useState} from "react"
 import Icon from "@mdi/react"
 import Popup from "reactjs-popup"
-import { mdiChartBellCurveCumulative, mdiDelete, mdiPlusThick, mdiSitemapOutline, mdiMenuDown } from "@mdi/js"
+import {mdiChartBellCurveCumulative, mdiDelete, mdiMenuDown, mdiPlusThick, mdiSitemapOutline} from "@mdi/js"
 import 'reactjs-popup/dist/index.css'
-import { toMap } from "./arrays"
-import { Range } from "immutable"
+import {toMap} from "./arrays"
+import {Range} from "immutable"
 import DataTable from 'react-data-table-component'
-import { FileInfo } from "./files"
-import { getLabelForChannel } from "../camilladsp/config"
+import {FileInfo} from "./files"
+import {getLabelForChannel} from "../camilladsp/config"
 import {cloneDeep} from "lodash"
 
 export function cssStyles(): CSSStyleDeclaration {
@@ -705,6 +705,30 @@ export function ErrorMessage(props: { message?: string }) {
     return props.message ?
         <div style={{ color: 'var(--error-text-color)', whiteSpace: 'pre-wrap' }}>{props.message}</div>
         : null
+}
+
+export interface ErrorBoundaryProps {
+    errorMessage?: string
+    children: ReactNode
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, {errorOccurred: boolean}> {
+    constructor(props: ErrorBoundaryProps) {
+        super(props);
+        this.state = {errorOccurred: false};
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo) {
+        this.setState({errorOccurred: true})
+    }
+
+    render() {
+        const errorMessage = "An error occured.\n\n" + (this.props.errorMessage || '')
+        const {errorOccurred} = this.state;
+        return errorOccurred ?
+            <ErrorMessage message={errorMessage}/>
+            : this.props.children;
+    }
 }
 
 export function BoolOption(props: {


### PR DESCRIPTION
Hi Henrik, I was not sure, if you want to include this in the 3.0 release, that's why I created a PR.

I Introduced `ErrorBoundary`s for each tab, which show all problematic config paths along with their error messages. This prevents the UI from vanishing completely when properties are missing (e.g. when loading a CDSP 2 config into CDSP 3).

Also, refactored the ErrorsForPath type into the Errors class and added tests.

For Testing:
If you load this config [StdInOut.txt](https://github.com/user-attachments/files/18355207/StdInOut.txt) with `chunksize: null` and open the `Devices` tab on the `next30` branch, you get an empty screen. With this PR, the tab is still broken, but you can see an error message describing the problem and the rest of the UI stays functional:

![image](https://github.com/user-attachments/assets/ca601ce8-5895-4b51-9c7a-212e69fc2236)
