### PR TITLE
Evaluate filters in the browser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Build and publish
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '24.x'
     - run: npm install
     - run: npm run build
     - name: ESLint

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           cache: npm
 
       - name: Install dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,9 +109,15 @@ volume})` and `evalFilterStep(config, index, ...)` return a `ChartContent`. They
 because a Conv reading a coefficient file has to ask the backend for the coefficients, through
 `POST /api/convcoeffs`; everything else resolves without touching the network, cheaply enough to
 run on every keystroke. Resolved coefficients are cached, keyed on the Conv parameters plus
-samplerate and channels, so dragging a control next to a Conv does not refetch it. The cache
-cannot see a file being replaced under a name it already holds, so anything that changes the
-coefficient files on the backend calls `clearCoefficientCache()`.
+samplerate and channels, so dragging a control next to a Conv does not refetch it. It is bounded by
+total size rather than entry count, 64 MB, because a Values filter is a handful of bytes while a
+room correction is megabytes. The cache cannot see a file being replaced under a name it already
+holds, so anything that changes the coefficient files on the backend calls `clearCoefficientCache()`.
+
+Coefficients arrive as raw floats rather than JSON, framed as a length-prefixed header and then the
+samples, and are kept as a typed array view over those bytes. The backend sends float32 where the
+source file holds no more than that, which halves the payload for the usual coefficient file and
+loses nothing. See `unframeCoefficients`.
 
 Four test files cover it:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ npm run lint         # eslint
 npm run format       # prettier
 ```
 
-Node >= 20.19.0 required (see `.nvmrc`).
+Node >= 22 required (see `.nvmrc`, and CI runs 24.x).
 
 ## Source layout (`src/`)
 
@@ -31,9 +31,10 @@ camilladsp/                 # Domain types + status polling
     index.ts                # evalFilter / evalFilterStep, and the Conv coefficient cache
     filters.ts              # Transfer function per filter type
     biquad.ts               # Biquad coefficients for all 17 subtypes
-    conv.ts                 # FFT, peak search, polar interpolation
+    conv.ts                 # FFT, peak search, polar interpolation, Conv group delay
     complex.ts              # Elementwise complex arithmetic over Float64Arrays
-    unwrap.ts               # Phase unwrapping and group delay
+    groupdelay.ts           # Group delay from the coefficients, Re(G/H)
+    unwrap.ts               # Phase unwrapping, for interpolating a Conv's phase
     defaults.ts             # CamillaDSP's defaults for optional parameters
     params.ts               # Narrowing helpers for the untyped parameter bag
     fixtures/variants.json  # every schema-valid filter config, see below
@@ -123,10 +124,19 @@ A convolution filter's `ChartContent` carries `phaseFloor`, the level more than 
 peak where an FIR's nulls sit closer together than the plot can sample, so a drawn phase there is
 aliasing rather than phase. The chart's toolbar offers an eye button, hiding on by default,
 which appears only when the curve actually goes that deep and swaps between `mdiEyeOff` and
-`mdiEye` to show which way it is set. **The group delay is always computed
-from a blanked phase, whatever the checkbox says**, because it predicts each step from the one below
-it in frequency: letting that run through the aliased region moved the readable group delay of a
-highpass by 608 ms. The phase trace has no such coupling, which is why only it is optional.
+`mdiEye` to show which way it is set. The group delay is blanked in the same places, so the two
+curves agree about where the filter stops being readable, but nothing depends on that any more.
+
+**The group delay is not read off the phase.** It comes from the coefficients, as
+`tau = Re(G/H)` where `G` is the transform of the coefficients weighted by their own index, which
+is what `scipy.signal.group_delay` computes. Every frequency stands alone, so there is no unwrap,
+no prediction carried up the grid, and no way for a point in the aliased region to move the
+passband. A biquad is a ratio of two three tap polynomials and sums along a cascade; a Conv gets a
+second FFT, of `n*h[n]`. What this replaced predicted each phase step from the one below it, which
+worked until a stopband null resolved the other way: a change in the last bit of the coefficients,
+which is what a different platform's `sin` and `cos` are worth, moved the readable delay of a
+highpass by 112 ms in half of all runs. `eval.test.ts` pins that down by shaking the coefficients
+by one ulp.
 
 Four test files cover it:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,15 @@ samples, and are kept as a typed array view over those bytes. The backend sends 
 source file holds no more than that, which halves the payload for the usual coefficient file and
 loses nothing. See `unframeCoefficients`.
 
+A convolution filter's `ChartContent` carries `phaseFloor`, the level more than 150 dB below its
+peak where an FIR's nulls sit closer together than the plot can sample, so a drawn phase there is
+aliasing rather than phase. The chart's toolbar offers an eye button, hiding on by default,
+which appears only when the curve actually goes that deep and swaps between `mdiEyeOff` and
+`mdiEye` to show which way it is set. **The group delay is always computed
+from a blanked phase, whatever the checkbox says**, because it predicts each step from the one below
+it in frequency: letting that run through the aliased region moved the readable group delay of a
+highpass by 608 ms. The phase trace has no such coupling, which is why only it is optional.
+
 Four test files cover it:
 
 - `properties.test.ts` is the one that matters. Every assertion is a closed-form property the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,16 @@ camilladsp/                 # Domain types + status polling
   status.ts                 # Status/state types
   usevumeterstatus.ts       # React hook for VU meter SSE stream
   versions.tsx              # Version mismatch UI
+  eval/                     # Filter evaluation — see below
+    index.ts                # evalFilter / evalFilterStep, and the Conv coefficient cache
+    filters.ts              # Transfer function per filter type
+    biquad.ts               # Biquad coefficients for all 17 subtypes
+    conv.ts                 # FFT, peak search, polar interpolation
+    complex.ts              # Elementwise complex arithmetic over Float64Arrays
+    unwrap.ts               # Phase unwrapping and group delay
+    defaults.ts             # CamillaDSP's defaults for optional parameters
+    params.ts               # Narrowing helpers for the untyped parameter bag
+    fixtures/variants.json  # every schema-valid filter config, see below
 
 # Tab components (one per GUI tab)
 titletab.tsx
@@ -90,7 +100,36 @@ Key endpoints used by the frontend:
 - `POST /api/setconfig` — push config to running DSP `{filename, config}`
 - `POST /api/saveconfigfile` — save config to disk `{filename, config}`
 - `GET /api/events` — SSE stream for status/level events
-- `POST /api/evalfilter` / `POST /api/evalfilterstep` — filter frequency response
+- `POST /api/convcoeffs` — coefficients of a Conv filter that reads a file
+
+## Filter evaluation
+
+Filter plots are computed here, not on the backend. `evalFilter(filter, {samplerate, channels,
+volume})` and `evalFilterStep(config, index, ...)` return a `ChartContent`. They are async only
+because a Conv reading a coefficient file has to ask the backend for the coefficients, through
+`POST /api/convcoeffs`; everything else resolves without touching the network, cheaply enough to
+run on every keystroke. Resolved coefficients are cached, keyed on the Conv parameters plus
+samplerate and channels, so dragging a control next to a Conv does not refetch it.
+
+Three test files cover it:
+
+- `properties.test.ts` is the one that matters. Every assertion is a closed-form property the
+  filter must satisfy, checked against no other implementation: a Butterworth of any order has the
+  Butterworth magnitude on the prewarped frequency axis, an allpass is unity everywhere, a peaking
+  filter is exactly its gain at the centre, a Linkwitz-Riley's two halves sum flat, a delay of N
+  samples has a group delay of N/fs. **Add to this file when you add a filter.** It fails on
+  wrongness rather than on change, so fixing a bug turns it green.
+- `filters.test.ts` covers the behaviour of each type: band roles, defaults, null handling, unknown
+  types raising rather than being dropped.
+- `variants.test.ts` evaluates every filter config the backend's JSON schemas allow, from
+  `fixtures/variants.json`, written by `camillagui-backend/tools/dump_filter_variants.py`. **The
+  schemas are in Python and the evaluator is in TypeScript**, so this is the only thing keeping
+  them coupled: when a filter schema changes, re-run that tool and commit the result. The backend's
+  `test_eval_validated_configs.py` fails until you do.
+
+A fixture of curves captured from the Python evaluator gated the original port, then was dropped.
+It only ever pinned what the GUI had been drawing, which nothing had verified against CamillaDSP,
+so a genuine fix would have shown up as dozens of red cases in an unreadable 1.8 MB blob.
 
 ## Key patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,16 +109,19 @@ volume})` and `evalFilterStep(config, index, ...)` return a `ChartContent`. They
 because a Conv reading a coefficient file has to ask the backend for the coefficients, through
 `POST /api/convcoeffs`; everything else resolves without touching the network, cheaply enough to
 run on every keystroke. Resolved coefficients are cached, keyed on the Conv parameters plus
-samplerate and channels, so dragging a control next to a Conv does not refetch it.
+samplerate and channels, so dragging a control next to a Conv does not refetch it. The cache
+cannot see a file being replaced under a name it already holds, so anything that changes the
+coefficient files on the backend calls `clearCoefficientCache()`.
 
-Three test files cover it:
+Four test files cover it:
 
 - `properties.test.ts` is the one that matters. Every assertion is a closed-form property the
   filter must satisfy, checked against no other implementation: a Butterworth of any order has the
   Butterworth magnitude on the prewarped frequency axis, an allpass is unity everywhere, a peaking
   filter is exactly its gain at the centre, a Linkwitz-Riley's two halves sum flat, a delay of N
-  samples has a group delay of N/fs. **Add to this file when you add a filter.** It fails on
-  wrongness rather than on change, so fixing a bug turns it green.
+  samples has a group delay of N/fs, a Conv whose impulse sits at sample N delays by N/fs and
+  flattens again once the bulk delay is removed. **Add to this file when you add a filter.** It
+  fails on wrongness rather than on change, so fixing a bug turns it green.
 - `filters.test.ts` covers the behaviour of each type: band roles, defaults, null handling, unknown
   types raising rather than being dropped.
 - `variants.test.ts` evaluates every filter config the backend's JSON schemas allow, from
@@ -126,6 +129,8 @@ Three test files cover it:
   schemas are in Python and the evaluator is in TypeScript**, so this is the only thing keeping
   them coupled: when a filter schema changes, re-run that tool and commit the result. The backend's
   `test_eval_validated_configs.py` fails until you do.
+- `eval.test.ts` covers the plumbing rather than the numbers: the coefficient cache, combining a
+  whole pipeline step, and the samplerate and channel options a step offers.
 
 A fixture of curves captured from the Python evaluator gated the original port, then was dropped.
 It only ever pinned what the GUI had been drawing, which nothing had verified against CamillaDSP,

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,8 @@
       },
       "devDependencies": {
         "@eslint/compat": "^2.0.4",
-        "@feedthrough/core": "^0.3.0",
-        "@feedthrough/vite": "^0.3.0",
+        "@feedthrough/core": "^0.4.0",
+        "@feedthrough/vite": "^0.4.0",
         "@mdi/js": "^7.4.47",
         "@mdi/react": "^1.6.1",
         "@tanstack/react-table": "^8.21.3",
@@ -848,20 +848,20 @@
       }
     },
     "node_modules/@feedthrough/core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@feedthrough/core/-/core-0.3.0.tgz",
-      "integrity": "sha512-ppues29qq5o7pzFyyqkjK9c62bEEKIzSt13bv5qUmjQd7eta4VF7NNk7IFKW3AxlbVofU7Qn8nZRxKujdkn+7Q==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@feedthrough/core/-/core-0.4.0.tgz",
+      "integrity": "sha512-MFlARDxVsJGLzEE9F68PqUgN2YQMOveesNQeZQ+lI4ijXXIg6wC73QRnRR++8Uxlx39pDVP85uil+/gl27eNXA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@feedthrough/vite": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@feedthrough/vite/-/vite-0.3.0.tgz",
-      "integrity": "sha512-dP8uRQjhDMoH6MySW8c2ar8ztUVWCrs1pK+cRVdAj4znupvsOq64KvM0KEs0vUO9L5a8RT9/dHr1VCAQJVAtrA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@feedthrough/vite/-/vite-0.4.0.tgz",
+      "integrity": "sha512-ir8f3jrGIkk31GzGxMtO4dSqt/anqnCCU1xeUcZad8k5CfL1ZE+HKSUKvACWjPhRBfj1Xt53MwIKdg+yrE1RDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@feedthrough/core": "0.3.0"
+        "@feedthrough/core": "0.4.0"
       },
       "engines": {
         "node": ">=22"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "camillagui",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "camillagui",
-      "version": "4.1.0",
+      "version": "5.0.0",
       "dependencies": {
         "@mdi/js": "^7.4.47",
         "@mdi/react": "^1.6.1",
@@ -24,8 +24,8 @@
       },
       "devDependencies": {
         "@eslint/compat": "^2.0.4",
-        "@feedthrough/core": "file:../feedthrough/packages/core",
-        "@feedthrough/vite": "file:../feedthrough/packages/vite",
+        "@feedthrough/core": "^0.3.0",
+        "@feedthrough/vite": "^0.3.0",
         "@mdi/js": "^7.4.47",
         "@mdi/react": "^1.6.1",
         "@tanstack/react-table": "^8.21.3",
@@ -68,37 +68,7 @@
         "yaml": "^2.8.3"
       },
       "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "../feedthrough/packages/core": {
-      "name": "@feedthrough/core",
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "devDependencies": {
-        "esbuild": "^0.28.0",
-        "typescript": "^5.8.3"
-      }
-    },
-    "../feedthrough/packages/vite": {
-      "name": "@feedthrough/vite",
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@feedthrough/core": "workspace:*"
-      },
-      "devDependencies": {
-        "@types/node": "^22.15.21",
-        "typescript": "^5.8.3",
-        "vite": "^6.0.0"
-      },
-      "engines": {
         "node": ">=22"
-      },
-      "peerDependencies": {
-        "vite": ">=5"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -878,12 +848,27 @@
       }
     },
     "node_modules/@feedthrough/core": {
-      "resolved": "../feedthrough/packages/core",
-      "link": true
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@feedthrough/core/-/core-0.3.0.tgz",
+      "integrity": "sha512-ppues29qq5o7pzFyyqkjK9c62bEEKIzSt13bv5qUmjQd7eta4VF7NNk7IFKW3AxlbVofU7Qn8nZRxKujdkn+7Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@feedthrough/vite": {
-      "resolved": "../feedthrough/packages/vite",
-      "link": true
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@feedthrough/vite/-/vite-0.3.0.tgz",
+      "integrity": "sha512-dP8uRQjhDMoH6MySW8c2ar8ztUVWCrs1pK+cRVdAj4znupvsOq64KvM0KEs0vUO9L5a8RT9/dHr1VCAQJVAtrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@feedthrough/core": "0.3.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "vite": ">=5"
+      }
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   },
   "devDependencies": {
     "@eslint/compat": "^2.0.4",
-    "@feedthrough/core": "^0.3.0",
-    "@feedthrough/vite": "^0.3.0",
+    "@feedthrough/core": "^0.4.0",
+    "@feedthrough/vite": "^0.4.0",
     "@mdi/js": "^7.4.47",
     "@mdi/react": "^1.6.1",
     "@tanstack/react-table": "^8.21.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": ".",
   "type": "module",
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22"
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
@@ -53,8 +53,8 @@
   },
   "devDependencies": {
     "@eslint/compat": "^2.0.4",
-    "@feedthrough/core": "file:../feedthrough/packages/core",
-    "@feedthrough/vite": "file:../feedthrough/packages/vite",
+    "@feedthrough/core": "^0.3.0",
+    "@feedthrough/vite": "^0.3.0",
     "@mdi/js": "^7.4.47",
     "@mdi/react": "^1.6.1",
     "@tanstack/react-table": "^8.21.3",

--- a/src/camilladsp/eval/biquad.ts
+++ b/src/camilladsp/eval/biquad.ts
@@ -1,0 +1,319 @@
+/**
+ * Biquad coefficients, ported from CamillaDSP's `src/filters/biquad.rs` by way
+ * of the GUI backend's former `backend/dsp/filters.py`.
+ */
+import { ComplexCurve, zeroCurve } from "./complex"
+import { FilterEvalError, flag, num, optNum, Params } from "./params"
+
+/** Normalized biquad coefficients, with a0 divided out. */
+export interface BiquadCoefficients {
+  a1: number
+  a2: number
+  b0: number
+  b1: number
+  b2: number
+}
+
+/**
+ * Q or bandwidth, whichever the config supplies. Peaking, Notch, Bandpass and
+ * Allpass all accept either, and the validator rejects a config that gives
+ * both or neither.
+ */
+function alphaFromQOrBandwidth(params: Params, omega: number, sn: number): number {
+  const q = optNum(params, "q")
+  if (q !== undefined) return sn / (2.0 * q)
+  const bandwidth = optNum(params, "bandwidth")
+  if (bandwidth !== undefined) return sn * Math.sinh(((Math.log(2.0) / 2.0) * bandwidth * omega) / sn)
+  throw new FilterEvalError("Missing 'q' or 'bandwidth'")
+}
+
+/**
+ * The shelf steepness, as either a slope in dB/octave or a Q. Returns the
+ * `beta` term the shelf coefficients are built from.
+ */
+function shelfBeta(params: Params, ampl: number, sn: number): number {
+  const slope = optNum(params, "slope")
+  if (slope !== undefined) {
+    const alpha = (sn / 2.0) * Math.sqrt((ampl + 1.0 / ampl) * (1.0 / (slope / 12.0) - 1.0) + 2.0)
+    return 2.0 * Math.sqrt(ampl) * alpha
+  }
+  const q = optNum(params, "q")
+  if (q !== undefined) return (sn * Math.sqrt(ampl)) / q
+  throw new FilterEvalError("Missing 'q' or 'slope'")
+}
+
+/**
+ * Coefficients for one biquad subtype.
+ *
+ * Unknown subtypes throw rather than falling through. The Python this was
+ * ported from used a chain that started with a stray `if` instead of `elif`,
+ * so an unrecognised subtype died with an UnboundLocalError instead.
+ */
+export function biquadCoefficients(params: Params, fs: number): BiquadCoefficients {
+  const ftype = params.type
+  let a0: number
+  let a1: number
+  let a2: number
+  let b0: number
+  let b1: number
+  let b2: number
+
+  switch (ftype) {
+    case "Free": {
+      a0 = 1.0
+      a1 = num(params, "a1")
+      a2 = num(params, "a2")
+      b0 = num(params, "b0")
+      b1 = num(params, "b1")
+      b2 = num(params, "b2")
+      break
+    }
+    case "Highpass": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const sn = Math.sin(omega)
+      const cs = Math.cos(omega)
+      const alpha = sn / (2.0 * num(params, "q"))
+      b0 = (1.0 + cs) / 2.0
+      b1 = -(1.0 + cs)
+      b2 = (1.0 + cs) / 2.0
+      a0 = 1.0 + alpha
+      a1 = -2.0 * cs
+      a2 = 1.0 - alpha
+      break
+    }
+    case "Lowpass": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const sn = Math.sin(omega)
+      const cs = Math.cos(omega)
+      const alpha = sn / (2.0 * num(params, "q"))
+      b0 = (1.0 - cs) / 2.0
+      b1 = 1.0 - cs
+      b2 = (1.0 - cs) / 2.0
+      a0 = 1.0 + alpha
+      a1 = -2.0 * cs
+      a2 = 1.0 - alpha
+      break
+    }
+    case "Peaking": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const sn = Math.sin(omega)
+      const cs = Math.cos(omega)
+      const ampl = Math.pow(10.0, num(params, "gain") / 40.0)
+      const alpha = alphaFromQOrBandwidth(params, omega, sn)
+      b0 = 1.0 + alpha * ampl
+      b1 = -2.0 * cs
+      b2 = 1.0 - alpha * ampl
+      a0 = 1.0 + alpha / ampl
+      a1 = -2.0 * cs
+      a2 = 1.0 - alpha / ampl
+      break
+    }
+    case "HighshelfFO": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const ampl = Math.pow(10.0, num(params, "gain") / 40.0)
+      const tn = Math.tan(omega / 2)
+      b0 = ampl * tn + ampl ** 2
+      b1 = ampl * tn - ampl ** 2
+      b2 = 0.0
+      a0 = ampl * tn + 1
+      a1 = ampl * tn - 1
+      a2 = 0.0
+      break
+    }
+    case "Highshelf": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const ampl = Math.pow(10.0, num(params, "gain") / 40.0)
+      const sn = Math.sin(omega)
+      const cs = Math.cos(omega)
+      const beta = shelfBeta(params, ampl, sn)
+      b0 = ampl * (ampl + 1.0 + (ampl - 1.0) * cs + beta)
+      b1 = -2.0 * ampl * (ampl - 1.0 + (ampl + 1.0) * cs)
+      b2 = ampl * (ampl + 1.0 + (ampl - 1.0) * cs - beta)
+      a0 = ampl + 1.0 - (ampl - 1.0) * cs + beta
+      a1 = 2.0 * (ampl - 1.0 - (ampl + 1.0) * cs)
+      a2 = ampl + 1.0 - (ampl - 1.0) * cs - beta
+      break
+    }
+    case "LowshelfFO": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const ampl = Math.pow(10.0, num(params, "gain") / 40.0)
+      const tn = Math.tan(omega / 2)
+      b0 = ampl ** 2 * tn + ampl
+      b1 = ampl ** 2 * tn - ampl
+      b2 = 0.0
+      a0 = tn + ampl
+      a1 = tn - ampl
+      a2 = 0.0
+      break
+    }
+    case "Lowshelf": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const ampl = Math.pow(10.0, num(params, "gain") / 40.0)
+      const sn = Math.sin(omega)
+      const cs = Math.cos(omega)
+      const beta = shelfBeta(params, ampl, sn)
+      b0 = ampl * (ampl + 1.0 - (ampl - 1.0) * cs + beta)
+      b1 = 2.0 * ampl * (ampl - 1.0 - (ampl + 1.0) * cs)
+      b2 = ampl * (ampl + 1.0 - (ampl - 1.0) * cs - beta)
+      a0 = ampl + 1.0 + (ampl - 1.0) * cs + beta
+      a1 = -2.0 * (ampl - 1.0 + (ampl + 1.0) * cs)
+      a2 = ampl + 1.0 + (ampl - 1.0) * cs - beta
+      break
+    }
+    case "LowpassFO": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const k = Math.tan(omega / 2.0)
+      const alpha = 1 + k
+      a0 = 1.0
+      a1 = -((1 - k) / alpha)
+      a2 = 0.0
+      b0 = k / alpha
+      b1 = k / alpha
+      b2 = 0
+      break
+    }
+    case "HighpassFO": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const k = Math.tan(omega / 2.0)
+      const alpha = 1 + k
+      a0 = 1.0
+      a1 = -((1 - k) / alpha)
+      a2 = 0.0
+      b0 = 1.0 / alpha
+      b1 = -1.0 / alpha
+      b2 = 0
+      break
+    }
+    case "Notch": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const sn = Math.sin(omega)
+      const cs = Math.cos(omega)
+      const alpha = alphaFromQOrBandwidth(params, omega, sn)
+      b0 = 1.0
+      b1 = -2.0 * cs
+      b2 = 1.0
+      a0 = 1.0 + alpha
+      a1 = -2.0 * cs
+      a2 = 1.0 - alpha
+      break
+    }
+    case "GeneralNotch": {
+      const fP = num(params, "freq_p")
+      const fZ = num(params, "freq_z")
+      const qP = num(params, "q_p")
+      const normalizeAtDc = flag(params, "normalize_at_dc")
+
+      // apply pre-warping
+      const tnZ = Math.tan((Math.PI * fZ) / fs)
+      const tnP = Math.tan((Math.PI * fP) / fs)
+      const alpha = tnP / qP
+      const tn2P = tnP ** 2
+      const tn2Z = tnZ ** 2
+
+      const gain = normalizeAtDc ? tn2P / tn2Z : 1.0
+
+      b0 = gain * (1.0 + tn2Z)
+      b1 = -2.0 * gain * (1.0 - tn2Z)
+      b2 = gain * (1.0 + tn2Z)
+      a0 = 1.0 + alpha + tn2P
+      a1 = -2.0 + 2.0 * tn2P
+      a2 = 1.0 - alpha + tn2P
+      break
+    }
+    case "Bandpass": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const sn = Math.sin(omega)
+      const cs = Math.cos(omega)
+      const alpha = alphaFromQOrBandwidth(params, omega, sn)
+      b0 = alpha
+      b1 = 0.0
+      b2 = -alpha
+      a0 = 1.0 + alpha
+      a1 = -2.0 * cs
+      a2 = 1.0 - alpha
+      break
+    }
+    case "Allpass": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const sn = Math.sin(omega)
+      const cs = Math.cos(omega)
+      const alpha = alphaFromQOrBandwidth(params, omega, sn)
+      b0 = 1.0 - alpha
+      b1 = -2.0 * cs
+      b2 = 1.0 + alpha
+      a0 = 1.0 + alpha
+      a1 = -2.0 * cs
+      a2 = 1.0 - alpha
+      break
+    }
+    case "AllpassFO": {
+      const omega = (2.0 * Math.PI * num(params, "freq")) / fs
+      const tn = Math.tan(omega / 2.0)
+      const alpha = (tn + 1.0) / (tn - 1.0)
+      b0 = 1.0
+      b1 = alpha
+      b2 = 0.0
+      a0 = alpha
+      a1 = 1.0
+      a2 = 0.0
+      break
+    }
+    case "LinkwitzTransform": {
+      const f0 = num(params, "freq_act")
+      const q0 = num(params, "q_act")
+      const qt = num(params, "q_target")
+      const ft = num(params, "freq_target")
+
+      const d0i = (2.0 * Math.PI * f0) ** 2
+      const d1i = (2.0 * Math.PI * f0) / q0
+      const c0i = (2.0 * Math.PI * ft) ** 2
+      const c1i = (2.0 * Math.PI * ft) / qt
+      const fc = (ft + f0) / 2.0
+
+      const gn = (2 * Math.PI * fc) / Math.tan((Math.PI * fc) / fs)
+      const cci = c0i + gn * c1i + gn ** 2
+
+      b0 = (d0i + gn * d1i + gn ** 2) / cci
+      b1 = (2 * (d0i - gn ** 2)) / cci
+      b2 = (d0i - gn * d1i + gn ** 2) / cci
+      a0 = 1.0
+      a1 = (2.0 * (c0i - gn ** 2)) / cci
+      a2 = (c0i - gn * c1i + gn ** 2) / cci
+      break
+    }
+    default:
+      throw new FilterEvalError(`Unknown Biquad subtype ${String(ftype)}`)
+  }
+
+  return { a1: a1 / a0, a2: a2 / a0, b0: b0 / a0, b1: b1 / a0, b2: b2 / a0 }
+}
+
+/**
+ * The transfer function of a biquad on a frequency vector, evaluated on the
+ * unit circle at z = exp(j*2*pi*f/fs).
+ */
+export function biquadComplexGain(coeffs: BiquadCoefficients, fs: number, freq: ArrayLike<number>): ComplexCurve {
+  const { a1, a2, b0, b1, b2 } = coeffs
+  const curve = zeroCurve(freq.length)
+  for (let n = 0; n < freq.length; n++) {
+    // z^-1 and z^-2 on the unit circle
+    const w = (2 * Math.PI * freq[n]) / fs
+    const c1 = Math.cos(w)
+    const s1 = -Math.sin(w)
+    const c2 = Math.cos(2 * w)
+    const s2 = -Math.sin(2 * w)
+    const nre = b0 + b1 * c1 + b2 * c2
+    const nim = b1 * s1 + b2 * s2
+    const dre = 1.0 + a1 * c1 + a2 * c2
+    const dim = a1 * s1 + a2 * s2
+    const denom = dre * dre + dim * dim
+    curve.re[n] = (nre * dre + nim * dim) / denom
+    curve.im[n] = (nim * dre - nre * dim) / denom
+  }
+  return curve
+}
+
+/** Build the biquad from a config and evaluate it in one step. */
+export function evalBiquad(params: Params, fs: number, freq: ArrayLike<number>): ComplexCurve {
+  return biquadComplexGain(biquadCoefficients(params, fs), fs, freq)
+}

--- a/src/camilladsp/eval/biquad.ts
+++ b/src/camilladsp/eval/biquad.ts
@@ -3,6 +3,7 @@
  * of the GUI backend's former `backend/dsp/filters.py`.
  */
 import { ComplexCurve, zeroCurve } from "./complex"
+import { rationalGroupDelay } from "./groupdelay"
 import { FilterEvalError, flag, num, optNum, Params } from "./params"
 
 /** Normalized biquad coefficients, with a0 divided out. */
@@ -313,7 +314,25 @@ export function biquadComplexGain(coeffs: BiquadCoefficients, fs: number, freq: 
   return curve
 }
 
+/**
+ * The group delay of a biquad in samples, from its coefficients.
+ *
+ * A biquad is a ratio of two three tap polynomials, so this is `rationalGroupDelay`
+ * with nothing added. Exact at every frequency, including at a Notch's own
+ * centre where the zero sits on the unit circle: that numerator is symmetric,
+ * so its delay is exactly its centre tap, one sample, however deep the null.
+ */
+export function biquadGroupDelay(coeffs: BiquadCoefficients, fs: number, freq: ArrayLike<number>): Float64Array {
+  const { a1, a2, b0, b1, b2 } = coeffs
+  return rationalGroupDelay([b0, b1, b2], [1.0, a1, a2], fs, freq)
+}
+
 /** Build the biquad from a config and evaluate it in one step. */
 export function evalBiquad(params: Params, fs: number, freq: ArrayLike<number>): ComplexCurve {
   return biquadComplexGain(biquadCoefficients(params, fs), fs, freq)
+}
+
+/** Build the biquad from a config and take its group delay in one step. */
+export function evalBiquadGroupDelay(params: Params, fs: number, freq: ArrayLike<number>): Float64Array {
+  return biquadGroupDelay(biquadCoefficients(params, fs), fs, freq)
 }

--- a/src/camilladsp/eval/complex.ts
+++ b/src/camilladsp/eval/complex.ts
@@ -95,24 +95,23 @@ export const PHASE_NOISE_FLOOR_DB = 150.0
  * through a full circle at each one. The plot's log grid is 155 Hz per point at
  * 20 kHz, so three of those nulls fall between neighbouring points and the
  * phase is sampled far too sparsely to show what it does. What gets drawn is
- * the aliasing, a hash of values between -180 and 180, and the group delay read
- * from it is worse. The magnitude is smooth at the same frequencies and is left
- * alone.
+ * the aliasing, a hash of values between -180 and 180. The magnitude is smooth
+ * at the same frequencies and is left alone.
  *
  * Only for a convolution filter. A 4th order Butterworth highpass at 1000 Hz is
  * 240 dB down at 1 Hz, deeper than anything here, and its phase is smooth,
  * slowly varying and perfectly readable: it has no nulls to rotate through.
  * Depth alone is not the problem, density of nulls is, and only an FIR has them.
  *
- * The group delay is always computed from a blanked copy, whatever the plot is
- * set to show, because the prediction it carries forward walks through this
- * region: on a highpass, whose unreadable stretch sits below the passband, an
- * unblanked phase moved the readable group delay by as much as 608 ms. What a
- * reader may switch back on is the phase trace itself, which is drawn point by
- * point and cannot mislead its neighbours.
+ * The group delay is hidden here too, so that the two curves agree about where
+ * the filter stops being readable. That is now only a display choice: the delay
+ * is computed from the coefficients rather than read off the phase, see
+ * `groupdelay.ts`, so a value in this region is wrong about itself and about
+ * nothing else. It used to be load bearing, and an unblanked phase moved the
+ * readable group delay of a highpass by as much as 608 ms.
  *
  * Blanked points are NaN, which the plot draws as a gap in the line rather
- * than as a value, and which `calcGroupDelay` propagates and ignores.
+ * than as a value.
  */
 export function phaseNoiseFloor(magnitude: ArrayLike<number>): number {
   let peak = -Infinity
@@ -120,7 +119,7 @@ export function phaseNoiseFloor(magnitude: ArrayLike<number>): number {
   return peak - PHASE_NOISE_FLOOR_DB
 }
 
-/** Blank the phase, in place, wherever the magnitude falls below `floor`. */
+/** Blank a curve, in place, wherever the magnitude falls below `floor`. */
 export function blankPhaseBelow(floor: number, magnitude: ArrayLike<number>, phase: number[]): void {
   for (let n = 0; n < phase.length; n++) if (magnitude[n] < floor) phase[n] = NaN
 }

--- a/src/camilladsp/eval/complex.ts
+++ b/src/camilladsp/eval/complex.ts
@@ -1,0 +1,57 @@
+/**
+ * Just enough complex arithmetic for filter evaluation.
+ *
+ * Evaluation is elementwise over a frequency vector, so a curve is a pair of
+ * Float64Arrays rather than an array of complex objects. That keeps the whole
+ * thing allocation free in the inner loops and avoids pulling in a complex
+ * number library for the handful of operations used here.
+ */
+
+export interface ComplexCurve {
+  re: Float64Array
+  im: Float64Array
+}
+
+export function zeroCurve(npoints: number): ComplexCurve {
+  return { re: new Float64Array(npoints), im: new Float64Array(npoints) }
+}
+
+/** A curve that is `value` at every point, with no imaginary part. */
+export function constantCurve(npoints: number, value: number): ComplexCurve {
+  const curve = zeroCurve(npoints)
+  curve.re.fill(value)
+  return curve
+}
+
+export function unitCurve(npoints: number): ComplexCurve {
+  return constantCurve(npoints, 1.0)
+}
+
+/** Multiply `target` by `factor` in place, elementwise. */
+export function multiplyInto(target: ComplexCurve, factor: ComplexCurve): void {
+  const { re, im } = target
+  for (let n = 0; n < re.length; n++) {
+    const r = re[n] * factor.re[n] - im[n] * factor.im[n]
+    const i = re[n] * factor.im[n] + im[n] * factor.re[n]
+    re[n] = r
+    im[n] = i
+  }
+}
+
+/** Magnitude in dB, with the same small offset the DSP plots use to keep log10 finite. */
+export function magnitudeDb(curve: ComplexCurve): number[] {
+  const out = new Array<number>(curve.re.length)
+  for (let n = 0; n < out.length; n++) {
+    out[n] = 20.0 * Math.log10(Math.hypot(curve.re[n], curve.im[n]) + 1.0e-15)
+  }
+  return out
+}
+
+/** Phase in degrees, wrapped to (-180, 180]. */
+export function phaseDegrees(curve: ComplexCurve): number[] {
+  const out = new Array<number>(curve.re.length)
+  for (let n = 0; n < out.length; n++) {
+    out[n] = Math.atan2(curve.im[n], curve.re[n]) * (180.0 / Math.PI)
+  }
+  return out
+}

--- a/src/camilladsp/eval/complex.ts
+++ b/src/camilladsp/eval/complex.ts
@@ -88,7 +88,7 @@ export function phaseDegrees(curve: ComplexCurve): number[] {
 export const PHASE_NOISE_FLOOR_DB = 150.0
 
 /**
- * Blank the phase, in place, deep below a convolution filter's passband.
+ * The level below which a convolution filter's phase is not worth drawing.
  *
  * The phase there is correct and unreadable. An FIR's stopband is a run of
  * nulls spaced fs/taps apart, 48 Hz for a 1001 tap filter, and the phase turns
@@ -104,12 +104,23 @@ export const PHASE_NOISE_FLOOR_DB = 150.0
  * slowly varying and perfectly readable: it has no nulls to rotate through.
  * Depth alone is not the problem, density of nulls is, and only an FIR has them.
  *
+ * The group delay is always computed from a blanked copy, whatever the plot is
+ * set to show, because the prediction it carries forward walks through this
+ * region: on a highpass, whose unreadable stretch sits below the passband, an
+ * unblanked phase moved the readable group delay by as much as 608 ms. What a
+ * reader may switch back on is the phase trace itself, which is drawn point by
+ * point and cannot mislead its neighbours.
+ *
  * Blanked points are NaN, which the plot draws as a gap in the line rather
  * than as a value, and which `calcGroupDelay` propagates and ignores.
  */
-export function blankNoisyPhase(magnitude: ArrayLike<number>, phase: number[]): void {
+export function phaseNoiseFloor(magnitude: ArrayLike<number>): number {
   let peak = -Infinity
   for (let n = 0; n < magnitude.length; n++) if (magnitude[n] > peak) peak = magnitude[n]
-  const floor = peak - PHASE_NOISE_FLOOR_DB
+  return peak - PHASE_NOISE_FLOOR_DB
+}
+
+/** Blank the phase, in place, wherever the magnitude falls below `floor`. */
+export function blankPhaseBelow(floor: number, magnitude: ArrayLike<number>, phase: number[]): void {
   for (let n = 0; n < phase.length; n++) if (magnitude[n] < floor) phase[n] = NaN
 }

--- a/src/camilladsp/eval/complex.ts
+++ b/src/camilladsp/eval/complex.ts
@@ -38,6 +38,24 @@ export function multiplyInto(target: ComplexCurve, factor: ComplexCurve): void {
   }
 }
 
+/**
+ * Multiply `target` in place by the response of a pure delay, `exp(-j*2*pi*f*t)`.
+ *
+ * Closed form at every frequency, so unlike a delay carried in a sampled phase
+ * curve there is nothing here to unwrap and no grid to be too coarse.
+ */
+export function applyDelayInto(target: ComplexCurve, delaySeconds: number, freq: ArrayLike<number>): void {
+  const { re, im } = target
+  for (let n = 0; n < re.length; n++) {
+    const angle = -2.0 * Math.PI * freq[n] * delaySeconds
+    const wr = Math.cos(angle)
+    const wi = Math.sin(angle)
+    const r = re[n] * wr - im[n] * wi
+    im[n] = re[n] * wi + im[n] * wr
+    re[n] = r
+  }
+}
+
 /** Magnitude in dB, with the same small offset the DSP plots use to keep log10 finite. */
 export function magnitudeDb(curve: ComplexCurve): number[] {
   const out = new Array<number>(curve.re.length)
@@ -54,4 +72,44 @@ export function phaseDegrees(curve: ComplexCurve): number[] {
     out[n] = Math.atan2(curve.im[n], curve.re[n]) * (180.0 / Math.PI)
   }
   return out
+}
+
+/**
+ * How far below a curve's own peak the phase stops being worth drawing.
+ *
+ * This is a legibility threshold, not an accuracy one. The numbers down there
+ * are right: a 1001 tap windowed sinc lowpass reaches -201 dB at 22 kHz, and
+ * the plot agrees with 80 digit arithmetic to 0.002 dB, because a float64 FFT
+ * of that filter does not reach its own noise floor until about -272 dB.
+ *
+ * 150 dB was picked by trying it on real filters. It took the hash out of the
+ * plots and hid nothing anyone wanted to see.
+ */
+export const PHASE_NOISE_FLOOR_DB = 150.0
+
+/**
+ * Blank the phase, in place, deep below a convolution filter's passband.
+ *
+ * The phase there is correct and unreadable. An FIR's stopband is a run of
+ * nulls spaced fs/taps apart, 48 Hz for a 1001 tap filter, and the phase turns
+ * through a full circle at each one. The plot's log grid is 155 Hz per point at
+ * 20 kHz, so three of those nulls fall between neighbouring points and the
+ * phase is sampled far too sparsely to show what it does. What gets drawn is
+ * the aliasing, a hash of values between -180 and 180, and the group delay read
+ * from it is worse. The magnitude is smooth at the same frequencies and is left
+ * alone.
+ *
+ * Only for a convolution filter. A 4th order Butterworth highpass at 1000 Hz is
+ * 240 dB down at 1 Hz, deeper than anything here, and its phase is smooth,
+ * slowly varying and perfectly readable: it has no nulls to rotate through.
+ * Depth alone is not the problem, density of nulls is, and only an FIR has them.
+ *
+ * Blanked points are NaN, which the plot draws as a gap in the line rather
+ * than as a value, and which `calcGroupDelay` propagates and ignores.
+ */
+export function blankNoisyPhase(magnitude: ArrayLike<number>, phase: number[]): void {
+  let peak = -Infinity
+  for (let n = 0; n < magnitude.length; n++) if (magnitude[n] > peak) peak = magnitude[n]
+  const floor = peak - PHASE_NOISE_FLOOR_DB
+  for (let n = 0; n < phase.length; n++) if (magnitude[n] < floor) phase[n] = NaN
 }

--- a/src/camilladsp/eval/conv.ts
+++ b/src/camilladsp/eval/conv.ts
@@ -146,6 +146,26 @@ export function interpolatePolar(curve: ComplexCurve, xold: Float64Array, xnew: 
 }
 
 /**
+ * The transform length for an impulse response: zero padded to at least one bin
+ * per Hz, not merely to the length of the impulse response.
+ *
+ * Padding costs nothing in accuracy, it evaluates the same transform at more
+ * frequencies, and the plot needs those frequencies: its log axis puts hundreds
+ * of points below 100 Hz, and a 2000 tap filter padded only to its own length
+ * has 23 Hz bins, so the whole knee of a highpass is drawn by interpolating
+ * across it. That was worth 4.7 dB of error at the knee, falling fourfold for
+ * every doubling of the length.
+ *
+ * The cost lands where it is affordable. A filter long enough for the FFT to be
+ * expensive already resolves better than a Hz, so nothing changes for it; a
+ * short filter is padded a long way, but a 65k point transform is a few
+ * milliseconds, once, and the result is cached.
+ */
+function paddedLength(taps: number, fs: number): number {
+  return Math.max(nextPow2(taps), nextPow2(fs))
+}
+
+/**
  * The half spectrum of an impulse response, on the FFT's own linear frequency
  * grid.
  *
@@ -158,19 +178,7 @@ export function convSpectrum(
   fs: number,
   removeDelay: boolean,
 ): { freq: Float64Array; curve: ComplexCurve } {
-  // Zero padded to at least one bin per Hz, not merely to the length of the
-  // impulse response. Padding costs nothing in accuracy, it evaluates the same
-  // transform at more frequencies, and the plot needs those frequencies: its
-  // log axis puts hundreds of points below 100 Hz, and a 2000 tap filter
-  // padded only to its own length has 23 Hz bins, so the whole knee of a
-  // highpass is drawn by interpolating across it. That was worth 4.7 dB of
-  // error at the knee, falling fourfold for every doubling of the length.
-  //
-  // The cost lands where it is affordable. A filter long enough for the FFT to
-  // be expensive already resolves better than a Hz, so nothing changes for it;
-  // a short filter is padded a long way, but a 65k point transform is a few
-  // milliseconds, once, and the result is cached.
-  const npoints = Math.max(nextPow2(impulse.length), nextPow2(fs))
+  const npoints = paddedLength(impulse.length, fs)
   const re = new Float64Array(npoints)
   const im = new Float64Array(npoints)
   re.set(impulse)
@@ -220,4 +228,56 @@ export function convComplexGain(
   const curve = interpolatePolar(spectrum.curve, spectrum.freq, freq)
   if (!removeDelay) applyDelayInto(curve, findPeak(impulse) / fs, freq)
   return curve
+}
+
+/**
+ * The group delay of a convolution filter, in samples, on the plot's grid.
+ *
+ * `Re(FFT(n*h) / FFT(h))`, the identity in `groupdelay.ts`, evaluated on the
+ * FFT's own grid and interpolated onto the plot's. Two transforms of the same
+ * padded length rather than one, which is the whole cost of this: no phase is
+ * formed, nothing is unwrapped, and a wild point at a stopband null stays that
+ * one point instead of moving every point above it in frequency.
+ *
+ * Interpolating is safe here in a way it is not for phase. The delay of a
+ * linear phase filter is a constant, and interpolating a constant is lossless,
+ * which is why a symmetric FIR comes back with exactly its centre tap even
+ * where its magnitude has nulls. Where the delay genuinely varies it varies
+ * smoothly, on a grid of at most 1 Hz.
+ *
+ * `removeDelay` matches `convComplexGain`: the bulk delay taken from the peak
+ * position is a constant number of samples, so here it is a subtraction rather
+ * than a rotation.
+ */
+export function convGroupDelay(
+  impulse: ArrayLike<number>,
+  fs: number,
+  freq: ArrayLike<number>,
+  removeDelay = false,
+): Float64Array {
+  const npoints = paddedLength(impulse.length, fs)
+  const hre = new Float64Array(npoints)
+  const him = new Float64Array(npoints)
+  hre.set(impulse)
+  fftInPlace(hre, him)
+
+  // the same impulse response weighted by its own sample index
+  const gre = new Float64Array(npoints)
+  const gim = new Float64Array(npoints)
+  for (let n = 0; n < impulse.length; n++) gre[n] = n * impulse[n]
+  fftInPlace(gre, gim)
+
+  const half = npoints / 2
+  const dense = new Float64Array(half)
+  for (let n = 0; n < half; n++) {
+    const denom = hre[n] * hre[n] + him[n] * him[n]
+    dense[n] = denom === 0.0 ? NaN : (gre[n] * hre[n] + gim[n] * him[n]) / denom
+  }
+
+  const out = interpolate(dense, (fs * (half - 1)) / npoints, freq)
+  if (removeDelay) {
+    const peak = findPeak(impulse)
+    for (let n = 0; n < out.length; n++) out[n] -= peak
+  }
+  return out
 }

--- a/src/camilladsp/eval/conv.ts
+++ b/src/camilladsp/eval/conv.ts
@@ -1,0 +1,191 @@
+/**
+ * Convolution filters: the FFT of an impulse response, interpolated onto the
+ * plot's log frequency grid.
+ */
+import { ComplexCurve, zeroCurve } from "./complex"
+import { unwrapPhase } from "./unwrap"
+
+/** The smallest power of two that is at least `n`. */
+export function nextPow2(n: number): number {
+  let points = 1
+  while (points < n) points *= 2
+  return points
+}
+
+/**
+ * In place iterative radix-2 Cooley-Tukey FFT. `re` and `im` must have a
+ * power of two length.
+ *
+ * Small enough to keep here rather than take a dependency for. A 262k point
+ * transform runs in single digit milliseconds, which is well under the time
+ * the round trip to the backend used to take, let alone the time the backend
+ * spent re-reading the coefficient file and transforming it there.
+ */
+export function fftInPlace(re: Float64Array, im: Float64Array): void {
+  const n = re.length
+  // bit reversal permutation
+  for (let i = 1, j = 0; i < n; i++) {
+    let bit = n >> 1
+    for (; j & bit; bit >>= 1) j ^= bit
+    j ^= bit
+    if (i < j) {
+      let tmp = re[i]
+      re[i] = re[j]
+      re[j] = tmp
+      tmp = im[i]
+      im[i] = im[j]
+      im[j] = tmp
+    }
+  }
+  // One twiddle table for the whole transform, each entry computed directly
+  // rather than carried forward by a recurrence, which would accumulate error
+  // across a stage. A 1M point transform would otherwise spend most of its
+  // time in Math.cos and Math.sin.
+  const half = n >> 1
+  const twiddleRe = new Float64Array(half)
+  const twiddleIm = new Float64Array(half)
+  for (let k = 0; k < half; k++) {
+    const angle = (-2 * Math.PI * k) / n
+    twiddleRe[k] = Math.cos(angle)
+    twiddleIm[k] = Math.sin(angle)
+  }
+  for (let len = 2; len <= n; len <<= 1) {
+    const halfLen = len >> 1
+    const stride = n / len
+    for (let i = 0; i < n; i += len) {
+      for (let k = 0; k < halfLen; k++) {
+        const wr = twiddleRe[k * stride]
+        const wi = twiddleIm[k * stride]
+        const a = i + k
+        const b = a + halfLen
+        const tr = re[b] * wr - im[b] * wi
+        const ti = re[b] * wi + im[b] * wr
+        re[b] = re[a] - tr
+        im[b] = im[a] - ti
+        re[a] += tr
+        im[a] += ti
+      }
+    }
+  }
+}
+
+/**
+ * The index of the largest magnitude sample. Ties resolve to the last index,
+ * matching the impulse peak search in the DSP.
+ */
+export function findPeak(impulse: ArrayLike<number>): number {
+  let peak = -1
+  let best = -1
+  for (let n = 0; n < impulse.length; n++) {
+    const magnitude = Math.abs(impulse[n])
+    if (magnitude >= best) {
+      best = magnitude
+      peak = n
+    }
+  }
+  return peak
+}
+
+/**
+ * Linear interpolation from the dense FFT grid onto the plot grid.
+ *
+ * The index mapping is `len(y) * xnew / xold[len-1]`, deliberately using the
+ * length rather than the last index, and clamps at the end of the array. That
+ * is what the DSP's own plots do, so it is kept exactly.
+ */
+function interpolate(y: Float64Array, xlast: number, xnew: ArrayLike<number>): Float64Array {
+  const out = new Float64Array(xnew.length)
+  const last = y.length - 1
+  for (let n = 0; n < xnew.length; n++) {
+    const idx = (y.length * xnew[n]) / xlast
+    const floor = Math.floor(idx)
+    const fract = idx - floor
+    const i1 = Math.min(floor, last)
+    const i2 = Math.min(i1 + 1, last)
+    out[n] = (1 - fract) * y[i1] + fract * y[i2]
+  }
+  return out
+}
+
+/**
+ * Interpolate a complex curve in polar form.
+ *
+ * The phase has to be unwrapped on the dense FFT grid before it can be
+ * interpolated, otherwise the wraps land between the sample points and the
+ * interpolation runs straight through them.
+ */
+export function interpolatePolar(curve: ComplexCurve, xold: Float64Array, xnew: ArrayLike<number>): ComplexCurve {
+  const npoints = curve.re.length
+  const magnitude = new Float64Array(npoints)
+  const wrapped = new Float64Array(npoints)
+  for (let n = 0; n < npoints; n++) {
+    magnitude[n] = Math.hypot(curve.re[n], curve.im[n])
+    wrapped[n] = Math.atan2(curve.im[n], curve.re[n]) * (180.0 / Math.PI)
+  }
+  const unwrapped = unwrapPhase(wrapped, 270.0)
+  for (let n = 0; n < npoints; n++) unwrapped[n] *= Math.PI / 180.0
+
+  const xlast = xold[xold.length - 1]
+  const magnitudeInterp = interpolate(magnitude, xlast, xnew)
+  const angleInterp = interpolate(unwrapped, xlast, xnew)
+
+  const out = zeroCurve(xnew.length)
+  for (let n = 0; n < xnew.length; n++) {
+    out.re[n] = magnitudeInterp[n] * Math.cos(angleInterp[n])
+    out.im[n] = magnitudeInterp[n] * Math.sin(angleInterp[n])
+  }
+  return out
+}
+
+/**
+ * The half spectrum of an impulse response, on the FFT's own linear frequency
+ * grid.
+ *
+ * `removeDelay` rotates out the bulk delay, taken from the position of the
+ * impulse peak, so that the phase plot of a linear phase filter stays readable
+ * instead of wrapping thousands of times.
+ */
+export function convSpectrum(
+  impulse: ArrayLike<number>,
+  fs: number,
+  removeDelay: boolean,
+): { freq: Float64Array; curve: ComplexCurve } {
+  const npoints = Math.max(1024, nextPow2(impulse.length))
+  const re = new Float64Array(npoints)
+  const im = new Float64Array(npoints)
+  re.set(impulse)
+  fftInPlace(re, im)
+
+  const half = npoints / 2
+  const freq = new Float64Array(half)
+  const curve = zeroCurve(half)
+  for (let n = 0; n < half; n++) {
+    freq[n] = (fs * n) / npoints
+    curve.re[n] = re[n]
+    curve.im[n] = im[n]
+  }
+  if (removeDelay) {
+    const maxidx = findPeak(impulse)
+    for (let n = 0; n < half; n++) {
+      const angle = (1.0 / (npoints / 2)) * Math.PI * n * maxidx
+      const wr = Math.cos(angle)
+      const wi = Math.sin(angle)
+      const r = curve.re[n] * wr - curve.im[n] * wi
+      const i = curve.re[n] * wi + curve.im[n] * wr
+      curve.re[n] = r
+      curve.im[n] = i
+    }
+  }
+  return { freq, curve }
+}
+
+/** The transfer function of a convolution filter on the plot's frequency grid. */
+export function convComplexGain(
+  impulse: ArrayLike<number>,
+  fs: number,
+  freq: ArrayLike<number>,
+  removeDelay = false,
+): ComplexCurve {
+  const spectrum = convSpectrum(impulse, fs, removeDelay)
+  return interpolatePolar(spectrum.curve, spectrum.freq, freq)
+}

--- a/src/camilladsp/eval/conv.ts
+++ b/src/camilladsp/eval/conv.ts
@@ -2,7 +2,7 @@
  * Convolution filters: the FFT of an impulse response, interpolated onto the
  * plot's log frequency grid.
  */
-import { ComplexCurve, zeroCurve } from "./complex"
+import { applyDelayInto, ComplexCurve, zeroCurve } from "./complex"
 import { unwrapPhase } from "./unwrap"
 
 /** The smallest power of two that is at least `n`. */
@@ -89,15 +89,23 @@ export function findPeak(impulse: ArrayLike<number>): number {
 /**
  * Linear interpolation from the dense FFT grid onto the plot grid.
  *
- * The index mapping is `len(y) * xnew / xold[len-1]`, deliberately using the
- * length rather than the last index, and clamps at the end of the array. That
- * is what the DSP's own plots do, so it is kept exactly.
+ * The grid is uniform, so a frequency maps straight onto a fractional index by
+ * dividing by the bin spacing. `xlast` is the last bin, at index `len - 1`, so
+ * the spacing is `xlast / (len - 1)`, and the index is `(len - 1) * f / xlast`.
+ *
+ * The Python this was ported from divided by the length instead, which stretched
+ * every Conv curve along the frequency axis by len/(len-1), a fifth of a percent
+ * with the usual 512 point half spectrum. That came from pycamilladsp-plot
+ * commit e4867a1, which replaced `np.interp` with index arithmetic and took the
+ * bin spacing from the wrong end of the fencepost. It is corrected here: a Conv
+ * whose impulse sits at sample N now has a group delay of exactly N/fs, where
+ * before it was 0.196% high at every frequency.
  */
 function interpolate(y: Float64Array, xlast: number, xnew: ArrayLike<number>): Float64Array {
   const out = new Float64Array(xnew.length)
   const last = y.length - 1
   for (let n = 0; n < xnew.length; n++) {
-    const idx = (y.length * xnew[n]) / xlast
+    const idx = ((y.length - 1) * xnew[n]) / xlast
     const floor = Math.floor(idx)
     const fract = idx - floor
     const i1 = Math.min(floor, last)
@@ -150,7 +158,19 @@ export function convSpectrum(
   fs: number,
   removeDelay: boolean,
 ): { freq: Float64Array; curve: ComplexCurve } {
-  const npoints = Math.max(1024, nextPow2(impulse.length))
+  // Zero padded to at least one bin per Hz, not merely to the length of the
+  // impulse response. Padding costs nothing in accuracy, it evaluates the same
+  // transform at more frequencies, and the plot needs those frequencies: its
+  // log axis puts hundreds of points below 100 Hz, and a 2000 tap filter
+  // padded only to its own length has 23 Hz bins, so the whole knee of a
+  // highpass is drawn by interpolating across it. That was worth 4.7 dB of
+  // error at the knee, falling fourfold for every doubling of the length.
+  //
+  // The cost lands where it is affordable. A filter long enough for the FFT to
+  // be expensive already resolves better than a Hz, so nothing changes for it;
+  // a short filter is padded a long way, but a 65k point transform is a few
+  // milliseconds, once, and the result is cached.
+  const npoints = Math.max(nextPow2(impulse.length), nextPow2(fs))
   const re = new Float64Array(npoints)
   const im = new Float64Array(npoints)
   re.set(impulse)
@@ -179,13 +199,25 @@ export function convSpectrum(
   return { freq, curve }
 }
 
-/** The transfer function of a convolution filter on the plot's frequency grid. */
+/**
+ * The transfer function of a convolution filter on the plot's frequency grid.
+ *
+ * The bulk delay is always taken out before the interpolation, whether or not
+ * the caller wants it in the result, because interpolating the phase means
+ * unwrapping it on the FFT grid first, and a peak sitting late in the impulse
+ * response turns the phase by more than half a circle from one bin to the next,
+ * which no unwrap can follow. Taking the peak out leaves a phase that barely
+ * moves between bins. Where the caller wants the delay it goes back on
+ * afterwards in closed form, which is exact at any length.
+ */
 export function convComplexGain(
   impulse: ArrayLike<number>,
   fs: number,
   freq: ArrayLike<number>,
   removeDelay = false,
 ): ComplexCurve {
-  const spectrum = convSpectrum(impulse, fs, removeDelay)
-  return interpolatePolar(spectrum.curve, spectrum.freq, freq)
+  const spectrum = convSpectrum(impulse, fs, true)
+  const curve = interpolatePolar(spectrum.curve, spectrum.freq, freq)
+  if (!removeDelay) applyDelayInto(curve, findPeak(impulse) / fs, freq)
+  return curve
 }

--- a/src/camilladsp/eval/defaults.ts
+++ b/src/camilladsp/eval/defaults.ts
@@ -1,0 +1,40 @@
+/**
+ * The values CamillaDSP substitutes for optional config parameters it was not
+ * given.
+ *
+ * The schemas deliberately declare these as `default: null`, because null means
+ * "not set" and lets the DSP apply its own default. So the evaluator has to
+ * know the real values. Keep them in step with the accessor defaults in
+ * CamillaDSP's `src/config/mod.rs`, and with `backend/dsp/defaults.py`, which
+ * still holds the ones the validator needs.
+ */
+
+/** GraphicEqualizerParameters::freq_min / freq_max */
+export const GRAPHIC_EQ_FREQ_MIN = 20.0
+export const GRAPHIC_EQ_FREQ_MAX = 20000.0
+
+/** LoudnessParameters::high_boost / low_boost, in dB */
+export const LOUDNESS_HIGH_BOOST = 10.0
+export const LOUDNESS_LOW_BOOST = 10.0
+
+/** LoudnessParameters::high_freq / low_freq, the shelf corner frequencies in Hz */
+export const LOUDNESS_HIGH_FREQ = 3500.0
+export const LOUDNESS_LOW_FREQ = 70.0
+
+/**
+ * LoudnessParameters::high_q / low_q. This Q gives the same shelves as the
+ * fixed slope of 12 dB/octave that CamillaDSP used before the parameters
+ * existed.
+ */
+export const LOUDNESS_HIGH_Q = 1.0 / Math.sqrt(2.0)
+export const LOUDNESS_LOW_Q = 1.0 / Math.sqrt(2.0)
+
+/** GainParameters::scale */
+export const GAIN_SCALE = "dB"
+
+/**
+ * BiquadCombo NPointPeq: a band whose gain is no larger than this is left out
+ * when the filter is built, which is how a band is disabled without removing
+ * it. See BiquadCombo::make_npeq in src/filters/biquadcombo.rs.
+ */
+export const NPOINT_PEQ_MIN_GAIN = 0.001

--- a/src/camilladsp/eval/eval.test.ts
+++ b/src/camilladsp/eval/eval.test.ts
@@ -13,7 +13,6 @@ import {
   intersectFilterOptions,
   logspace,
 } from "./index"
-import { calcGroupDelay } from "./unwrap"
 import { FilterOption } from "../../utilities/chart"
 import { Config, defaultConfig, Filter } from "../config"
 
@@ -236,25 +235,56 @@ describe("a phase too deep to be readable", () => {
     expect(Math.min(...result.magnitude!)).toBeLessThan(-200)
   })
 
-  it("leaves out the group delay there, which is not the plot's choice", async () => {
+  it("hides the group delay in the same places, so the two curves agree", async () => {
+    // Cosmetic now, where it used to be the thing keeping the delay honest.
+    // One value per plot frequency, so a gap is that point being too deep.
     const result = await evalFilter(windowedSinc(1000.0), { samplerate: 48000, channels: 2 })
-    const gaps = result.groupdelay!.map((d, n) => [d, n] as const).filter(([d]) => !Number.isFinite(d))
-    expect(gaps.length).toBeGreaterThan(0)
-    // group delay sits on the midpoints, so a gap means either end is too deep
-    gaps.forEach(([, n]) =>
-      expect(Math.min(result.magnitude![n], result.magnitude![n + 1])).toBeLessThan(result.phaseFloor!),
-    )
+    const blanked = result.groupdelay!.map((d, n) => n).filter((n) => !Number.isFinite(result.groupdelay![n]))
+    expect(blanked.length).toBeGreaterThan(0)
+    expect(result.f_groupdelay!.length).toBe(result.f.length)
+    result.groupdelay!.forEach((delay, n) => {
+      expect(Number.isFinite(delay)).toBe(result.magnitude![n] >= result.phaseFloor!)
+    })
   })
 
   it("does not let the unreadable region move the group delay that is readable", async () => {
-    // The point of computing it from a blanked phase. On a highpass the
-    // unreadable stretch sits below the passband, so a prediction carried up
-    // through it lands hundreds of ms out on the part anyone looks at.
+    // On a highpass the unreadable stretch sits below the passband. Reading the
+    // delay off the phase meant carrying a prediction up through it, which
+    // landed hundreds of ms out on the part anyone looks at.
     const result = await evalFilter(windowedSinc(1000.0, true), { samplerate: 48000, channels: 2 })
     const readable = result.groupdelay!.filter((d, n) => Number.isFinite(d) && result.magnitude![n] > -60)
     expect(readable.length).toBeGreaterThan(100)
     // a 1001 tap linear phase filter, plotted with its bulk delay removed
     readable.forEach((delay) => expect(Math.abs(delay)).toBeLessThan(1.0))
+  })
+
+  it("gives the same answer when the coefficients move in their last bit", async () => {
+    // The regression test for what this replaced. The stopband of an FIR is a
+    // run of nulls whose phase is aliasing hash, and the old prediction chain
+    // walked through it, so which way each 180 degree step resolved decided the
+    // passband delay. A relative 1e-16 on the coefficients, which is what a
+    // different platform's sin and cos are worth, flipped it 8 times in 20 and
+    // put a whole turn of the grid, 112 ms, into the readable part.
+    // one ulp up or down, the smallest change a coefficient can have and still
+    // be a different number
+    let seed = 0x9e3779b9
+    const jitter = () => {
+      seed = (seed * 1664525 + 1013904223) >>> 0
+      return 1.0 + Number.EPSILON * (seed % 3 === 0 ? -1 : seed % 3 === 1 ? 0 : 1)
+    }
+    for (let run = 0; run < 20; run++) {
+      const base = windowedSinc(1000.0, true).parameters!.values as number[]
+      const shaken: Filter = {
+        type: "Conv",
+        description: null,
+        parameters: { type: "Values", values: base.map((v) => v * jitter()) },
+      }
+      clearCoefficientCache()
+      const result = await evalFilter(shaken, { samplerate: 48000, channels: 2 })
+      const readable = result.groupdelay!.filter((d, n) => Number.isFinite(d) && result.magnitude![n] > -60)
+      expect(readable.length).toBeGreaterThan(100)
+      readable.forEach((delay) => expect(Math.abs(delay)).toBeLessThan(1.0))
+    }
   })
 
   it("has no floor for a filter evaluated in closed form, however far down it goes", async () => {
@@ -275,33 +305,6 @@ describe("a phase too deep to be readable", () => {
     const phase = [1.0, 2.0, 3.0]
     blankPhaseBelow(-110.0, [40.0, -100.0, -120.0], phase)
     expect(phase.map(Number.isFinite)).toEqual([true, true, false])
-  })
-
-  it("takes the group delay with it, rather than reading one off noise", () => {
-    const freq = [100.0, 200.0, 300.0, 400.0]
-    const phase = [0.0, -10.0, NaN, -30.0]
-    const result = calcGroupDelay(freq, phase)
-    expect(result.groupdelay.map(Number.isFinite)).toEqual([true, false, false])
-  })
-
-  it("does not let a blanked stretch teach the prediction anything", () => {
-    // A constant 7 ms delay on the grid the plots use, with a hole blanked out
-    // of the middle of it. By the top of the grid the phase is turning through
-    // three whole circles between neighbouring points, so the points after the
-    // hole are only right if the prediction picked up where it left off rather
-    // than learning from the hole.
-    const freq = Array.from(logspace(10.0, 22800.0, 1000))
-    const phase = freq.map((f) => {
-      const wrapped = (((-360.0 * f * 0.007 + 180.0) % 360.0) + 360.0) % 360.0
-      return wrapped - 180.0
-    })
-    for (let n = 600; n < 640; n++) phase[n] = NaN
-    const result = calcGroupDelay(freq, phase)
-    result.groupdelay.forEach((delay, n) => {
-      if (Number.isFinite(delay)) expect(delay).toBeCloseTo(7.0, 9)
-      else expect(n).toBeGreaterThanOrEqual(599)
-    })
-    expect(result.groupdelay.slice(645).every((d) => Math.abs(d - 7.0) < 1e-9)).toBe(true)
   })
 })
 

--- a/src/camilladsp/eval/eval.test.ts
+++ b/src/camilladsp/eval/eval.test.ts
@@ -1,11 +1,13 @@
 /**
- * Behaviour around the evaluator that the golden fixture cannot cover: the
- * coefficient cache, combining a whole pipeline step, and the samplerate and
- * channel options a step offers.
+ * The plumbing around the evaluator rather than its numbers: the coefficient
+ * cache, combining a whole pipeline step, and the samplerate and channel
+ * options a step offers.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { Config, defaultConfig, Filter } from "../config"
+import { blankNoisyPhase } from "./complex"
 import { clearCoefficientCache, evalFilter, evalFilterStep, intersectFilterOptions, logspace } from "./index"
+import { calcGroupDelay } from "./unwrap"
 
 function convFilter(filename: string): Filter {
   return {
@@ -70,6 +72,23 @@ describe("coefficient cache", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
+  it("keeps the entries it is still being asked for, not the ones fetched first", async () => {
+    // The cache holds a few megabytes per entry, so it is small. Evicting in
+    // fetch order would throw out the filter being edited as soon as enough
+    // others had been plotted after it.
+    const fetchMock = stubCoefficients()
+    const first = convFilter("first.raw")
+    await evalFilter(first, filterOptions)
+    for (let n = 0; n < 7; n++) await evalFilter(convFilter(`other${n}.raw`), filterOptions)
+    // still in the cache, and using it moves it to the front
+    await evalFilter(first, filterOptions)
+    expect(fetchMock).toHaveBeenCalledTimes(8)
+    // one more entry pushes out the least recently used, which is no longer this one
+    await evalFilter(convFilter("last.raw"), filterOptions)
+    await evalFilter(first, filterOptions)
+    expect(fetchMock).toHaveBeenCalledTimes(9)
+  })
+
   it("does not go to the backend for a Conv that carries its own values", async () => {
     const fetchMock = stubCoefficients()
     const filter: Filter = {
@@ -123,6 +142,102 @@ describe("filter step evaluation", () => {
     const single = await evalFilter(gainFilter(0.0), filterOptions)
     expect(step.f[0]).toBeCloseTo(10.0, 12)
     expect(single.f[0]).toBeCloseTo(1.0, 12)
+  })
+})
+
+describe("a phase too deep to be readable", () => {
+  beforeEach(() => {
+    clearCoefficientCache()
+    vi.restoreAllMocks()
+  })
+
+  /** A 1001 tap windowed sinc lowpass, whose stopband runs past -200 dB. */
+  function sincLowpass(cutoff: number): Filter {
+    const taps = 1001
+    const centre = (taps - 1) / 2
+    const fc = cutoff / 48000
+    const values = Array.from({ length: taps }, (_, n) => {
+      const k = n - centre
+      const sinc = k === 0 ? 2 * fc : Math.sin(2 * Math.PI * fc * k) / (Math.PI * k)
+      return sinc * (0.5 - 0.5 * Math.cos((2 * Math.PI * n) / (taps - 1)))
+    })
+    return { type: "Conv", description: null, parameters: { type: "Values", values } }
+  }
+
+  it("is left out of an FIR's deep stopband, along with its group delay", async () => {
+    const result = await evalFilter(sincLowpass(1000.0), { samplerate: 48000, channels: 2 })
+    const magnitude = result.magnitude!
+    const floor = Math.max(...magnitude) - 150
+    const blanked = result.phase!.map((p, i) => [p, i] as const).filter(([p]) => !Number.isFinite(p))
+    expect(blanked.length).toBeGreaterThan(50)
+    // nothing is hidden that is not far below everything else on the plot
+    blanked.forEach(([, i]) => expect(magnitude[i]).toBeLessThan(floor))
+    expect(result.groupdelay!.some((d) => !Number.isFinite(d))).toBe(true)
+  })
+
+  it("keeps the magnitude, which is smooth where the phase is hash", async () => {
+    const result = await evalFilter(sincLowpass(1000.0), { samplerate: 48000, channels: 2 })
+    expect(Math.min(...result.magnitude!)).toBeLessThan(-200)
+    expect(result.magnitude!.every(Number.isFinite)).toBe(true)
+  })
+
+  it("keeps every point of the phase that is above the floor", async () => {
+    const result = await evalFilter(sincLowpass(1000.0), { samplerate: 48000, channels: 2 })
+    const magnitude = result.magnitude!
+    const floor = Math.max(...magnitude) - 150
+    result.phase!.forEach((p, i) => {
+      if (magnitude[i] >= floor) expect(Number.isFinite(p)).toBe(true)
+    })
+  })
+
+  it("is measured from the curve's own peak", () => {
+    const magnitude = [40.0, -100.0, -120.0]
+    const phase = [1.0, 2.0, 3.0]
+    blankNoisyPhase(magnitude, phase)
+    // 40 dB peak, so the floor is at -110 dB
+    expect(phase.map(Number.isFinite)).toEqual([true, true, false])
+  })
+
+  it("takes the group delay with it, rather than reading one off noise", () => {
+    const freq = [100.0, 200.0, 300.0, 400.0]
+    const phase = [0.0, -10.0, NaN, -30.0]
+    const result = calcGroupDelay(freq, phase)
+    expect(result.groupdelay.map(Number.isFinite)).toEqual([true, false, false])
+  })
+
+  it("does not let a blanked stretch teach the prediction anything", () => {
+    // A constant 7 ms delay on the grid the plots use, with a hole blanked out
+    // of the middle of it. By the top of the grid the phase is turning through
+    // three whole circles between neighbouring points, so the points after the
+    // hole are only right if the prediction picked up where it left off rather
+    // than learning from the hole.
+    const freq = Array.from(logspace(10.0, 22800.0, 1000))
+    const phase = freq.map((f) => {
+      const wrapped = (((-360.0 * f * 0.007 + 180.0) % 360.0) + 360.0) % 360.0
+      return wrapped - 180.0
+    })
+    for (let n = 600; n < 640; n++) phase[n] = NaN
+    const result = calcGroupDelay(freq, phase)
+    result.groupdelay.forEach((delay, n) => {
+      if (Number.isFinite(delay)) expect(delay).toBeCloseTo(7.0, 9)
+      else expect(n).toBeGreaterThanOrEqual(599)
+    })
+    expect(result.groupdelay.slice(645).every((d) => Math.abs(d - 7.0) < 1e-9)).toBe(true)
+  })
+
+  it("leaves a filter evaluated in closed form alone, however far down it goes", async () => {
+    // a 4th order highpass at 1 kHz really is 240 dB down at 1 Hz, deeper than
+    // anything blanked above, and its phase there is smooth and readable: no
+    // nulls to rotate through, so nothing for the grid to alias
+    const highpass: Filter = {
+      type: "BiquadCombo",
+      description: null,
+      parameters: { type: "ButterworthHighpass", order: 4, freq: 1000.0 },
+    }
+    const result = await evalFilter(highpass, { samplerate: 48000, channels: 2 })
+    expect(Math.min(...result.magnitude!)).toBeLessThan(-200)
+    expect(result.phase!.every(Number.isFinite)).toBe(true)
+    expect(result.groupdelay!.every(Number.isFinite)).toBe(true)
   })
 })
 

--- a/src/camilladsp/eval/eval.test.ts
+++ b/src/camilladsp/eval/eval.test.ts
@@ -4,10 +4,18 @@
  * options a step offers.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { Config, defaultConfig, Filter } from "../config"
 import { blankNoisyPhase } from "./complex"
-import { clearCoefficientCache, evalFilter, evalFilterStep, intersectFilterOptions, logspace } from "./index"
+import {
+  clearCoefficientCache,
+  entriesToEvict,
+  evalFilter,
+  evalFilterStep,
+  intersectFilterOptions,
+  logspace,
+} from "./index"
 import { calcGroupDelay } from "./unwrap"
+import { FilterOption } from "../../utilities/chart"
+import { Config, defaultConfig, Filter } from "../config"
 
 function convFilter(filename: string): Filter {
   return {
@@ -21,8 +29,25 @@ function gainFilter(gain: number): Filter {
   return { type: "Gain", description: null, parameters: { gain, scale: "dB" } }
 }
 
+/** The framing the backend replies with: header length, header, padding, samples. */
+export function frameCoefficients(
+  coefficients: number[],
+  format: "float32" | "float64" = "float64",
+  options: FilterOption[] = [],
+): ArrayBuffer {
+  const header = new TextEncoder().encode(JSON.stringify({ options, format }))
+  const start = 4 + header.length + ((8 - ((4 + header.length) % 8)) % 8)
+  const width = format === "float32" ? 4 : 8
+  const buffer = new ArrayBuffer(start + width * coefficients.length)
+  new DataView(buffer).setUint32(0, header.length, true)
+  new Uint8Array(buffer, 4, header.length).set(header)
+  if (format === "float32") new Float32Array(buffer, start).set(coefficients)
+  else new Float64Array(buffer, start).set(coefficients)
+  return buffer
+}
+
 function stubCoefficients(coefficients: number[] = [1.0, 0.0, 0.0, 0.0]) {
-  const fetchMock = vi.fn(async () => new Response(JSON.stringify({ options: [], coefficients })))
+  const fetchMock = vi.fn(async () => new Response(frameCoefficients(coefficients)))
   vi.stubGlobal("fetch", fetchMock)
   return fetchMock
 }
@@ -72,21 +97,52 @@ describe("coefficient cache", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
+  it.each([
+    // sizes in least recently used order, budget, how many of the oldest go
+    [[10, 10, 10], 100, 0],
+    [[60, 60], 100, 1],
+    [[60, 20, 20], 100, 0], // exactly the budget, nothing has to go
+    [[70, 20, 20], 100, 1],
+    [[90, 90, 90], 100, 2],
+    // never the newest, even when it does not fit on its own
+    [[200], 100, 0],
+    [[10, 200], 100, 1],
+    [[], 100, 0],
+  ] as const)("evicts %j against a budget of %i", (sizes, budget, expected) => {
+    expect(entriesToEvict([...sizes], budget)).toBe(expected)
+  })
+
+  it("keeps a dozen small entries, where a cap on the count would not", async () => {
+    // the sizes differ by orders of magnitude, so counting entries is the wrong
+    // bound: twelve short impulse responses are nothing at all
+    const fetchMock = stubCoefficients([1.0, 0.0])
+    for (let n = 0; n < 12; n++) await evalFilter(convFilter(`small${n}.raw`), filterOptions)
+    expect(fetchMock).toHaveBeenCalledTimes(12)
+    await evalFilter(convFilter("small0.raw"), filterOptions)
+    expect(fetchMock).toHaveBeenCalledTimes(12)
+  })
+
   it("keeps the entries it is still being asked for, not the ones fetched first", async () => {
-    // The cache holds a few megabytes per entry, so it is small. Evicting in
-    // fetch order would throw out the filter being edited as soon as enough
-    // others had been plotted after it.
+    // Using an entry has to move it to the front, or the filter being edited
+    // would be evicted as soon as enough others had been plotted after it.
     const fetchMock = stubCoefficients()
     const first = convFilter("first.raw")
     await evalFilter(first, filterOptions)
     for (let n = 0; n < 7; n++) await evalFilter(convFilter(`other${n}.raw`), filterOptions)
-    // still in the cache, and using it moves it to the front
     await evalFilter(first, filterOptions)
     expect(fetchMock).toHaveBeenCalledTimes(8)
-    // one more entry pushes out the least recently used, which is no longer this one
-    await evalFilter(convFilter("last.raw"), filterOptions)
-    await evalFilter(first, filterOptions)
-    expect(fetchMock).toHaveBeenCalledTimes(9)
+  })
+
+  it.each(["float32", "float64"] as const)("reads a %s reply", async (format) => {
+    // the backend picks the width from what the source file can hold, so both
+    // have to come back as usable coefficients
+    const coefficients = [1.0, -0.5, 0.25, 0.0]
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(frameCoefficients(coefficients, format))),
+    )
+    const result = await evalFilter(convFilter("impulse.raw"), filterOptions)
+    expect(Array.from(result.impulse!)).toEqual(coefficients)
   })
 
   it("does not go to the backend for a Conv that carries its own values", async () => {

--- a/src/camilladsp/eval/eval.test.ts
+++ b/src/camilladsp/eval/eval.test.ts
@@ -4,7 +4,7 @@
  * options a step offers.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { blankNoisyPhase } from "./complex"
+import { blankPhaseBelow, phaseNoiseFloor } from "./complex"
 import {
   clearCoefficientCache,
   entriesToEvict,
@@ -207,50 +207,73 @@ describe("a phase too deep to be readable", () => {
     vi.restoreAllMocks()
   })
 
-  /** A 1001 tap windowed sinc lowpass, whose stopband runs past -200 dB. */
-  function sincLowpass(cutoff: number): Filter {
+  /** A windowed sinc, whose stopband runs past -200 dB. */
+  function windowedSinc(cutoff: number, highpass = false): Filter {
     const taps = 1001
     const centre = (taps - 1) / 2
     const fc = cutoff / 48000
     const values = Array.from({ length: taps }, (_, n) => {
       const k = n - centre
-      const sinc = k === 0 ? 2 * fc : Math.sin(2 * Math.PI * fc * k) / (Math.PI * k)
-      return sinc * (0.5 - 0.5 * Math.cos((2 * Math.PI * n) / (taps - 1)))
+      const lowpass = k === 0 ? 2 * fc : Math.sin(2 * Math.PI * fc * k) / (Math.PI * k)
+      const value = highpass ? (k === 0 ? 1 : 0) - lowpass : lowpass
+      const x = (2 * Math.PI * n) / (taps - 1)
+      return value * (0.42 - 0.5 * Math.cos(x) + 0.08 * Math.cos(2 * x))
     })
     return { type: "Conv", description: null, parameters: { type: "Values", values } }
   }
 
-  it("is left out of an FIR's deep stopband, along with its group delay", async () => {
-    const result = await evalFilter(sincLowpass(1000.0), { samplerate: 48000, channels: 2 })
+  it("reports the level it starts at, so the plot can offer to hide it", async () => {
+    const result = await evalFilter(windowedSinc(1000.0), { samplerate: 48000, channels: 2 })
     const magnitude = result.magnitude!
-    const floor = Math.max(...magnitude) - 150
-    const blanked = result.phase!.map((p, i) => [p, i] as const).filter(([p]) => !Number.isFinite(p))
-    expect(blanked.length).toBeGreaterThan(50)
-    // nothing is hidden that is not far below everything else on the plot
-    blanked.forEach(([, i]) => expect(magnitude[i]).toBeLessThan(floor))
-    expect(result.groupdelay!.some((d) => !Number.isFinite(d))).toBe(true)
+    expect(result.phaseFloor).toBeCloseTo(Math.max(...magnitude) - 150, 9)
+    expect(magnitude.filter((value) => value < result.phaseFloor!).length).toBeGreaterThan(50)
   })
 
-  it("keeps the magnitude, which is smooth where the phase is hash", async () => {
-    const result = await evalFilter(sincLowpass(1000.0), { samplerate: 48000, channels: 2 })
-    expect(Math.min(...result.magnitude!)).toBeLessThan(-200)
+  it("still delivers every point of the phase, hiding it being the plot's choice", async () => {
+    const result = await evalFilter(windowedSinc(1000.0), { samplerate: 48000, channels: 2 })
+    expect(result.phase!.every(Number.isFinite)).toBe(true)
     expect(result.magnitude!.every(Number.isFinite)).toBe(true)
+    expect(Math.min(...result.magnitude!)).toBeLessThan(-200)
   })
 
-  it("keeps every point of the phase that is above the floor", async () => {
-    const result = await evalFilter(sincLowpass(1000.0), { samplerate: 48000, channels: 2 })
-    const magnitude = result.magnitude!
-    const floor = Math.max(...magnitude) - 150
-    result.phase!.forEach((p, i) => {
-      if (magnitude[i] >= floor) expect(Number.isFinite(p)).toBe(true)
-    })
+  it("leaves out the group delay there, which is not the plot's choice", async () => {
+    const result = await evalFilter(windowedSinc(1000.0), { samplerate: 48000, channels: 2 })
+    const gaps = result.groupdelay!.map((d, n) => [d, n] as const).filter(([d]) => !Number.isFinite(d))
+    expect(gaps.length).toBeGreaterThan(0)
+    // group delay sits on the midpoints, so a gap means either end is too deep
+    gaps.forEach(([, n]) =>
+      expect(Math.min(result.magnitude![n], result.magnitude![n + 1])).toBeLessThan(result.phaseFloor!),
+    )
   })
 
-  it("is measured from the curve's own peak", () => {
-    const magnitude = [40.0, -100.0, -120.0]
+  it("does not let the unreadable region move the group delay that is readable", async () => {
+    // The point of computing it from a blanked phase. On a highpass the
+    // unreadable stretch sits below the passband, so a prediction carried up
+    // through it lands hundreds of ms out on the part anyone looks at.
+    const result = await evalFilter(windowedSinc(1000.0, true), { samplerate: 48000, channels: 2 })
+    const readable = result.groupdelay!.filter((d, n) => Number.isFinite(d) && result.magnitude![n] > -60)
+    expect(readable.length).toBeGreaterThan(100)
+    // a 1001 tap linear phase filter, plotted with its bulk delay removed
+    readable.forEach((delay) => expect(Math.abs(delay)).toBeLessThan(1.0))
+  })
+
+  it("has no floor for a filter evaluated in closed form, however far down it goes", async () => {
+    const highpass: Filter = {
+      type: "BiquadCombo",
+      description: null,
+      parameters: { type: "ButterworthHighpass", order: 4, freq: 1000.0 },
+    }
+    const result = await evalFilter(highpass, { samplerate: 48000, channels: 2 })
+    expect(result.phaseFloor).toBeUndefined()
+    expect(Math.min(...result.magnitude!)).toBeLessThan(-200)
+    expect(result.phase!.every(Number.isFinite)).toBe(true)
+    expect(result.groupdelay!.every(Number.isFinite)).toBe(true)
+  })
+
+  it("measures the floor from the curve's own peak", () => {
+    expect(phaseNoiseFloor([40.0, -100.0, -120.0])).toBeCloseTo(-110.0, 9)
     const phase = [1.0, 2.0, 3.0]
-    blankNoisyPhase(magnitude, phase)
-    // 40 dB peak, so the floor is at -110 dB
+    blankPhaseBelow(-110.0, [40.0, -100.0, -120.0], phase)
     expect(phase.map(Number.isFinite)).toEqual([true, true, false])
   })
 
@@ -279,21 +302,6 @@ describe("a phase too deep to be readable", () => {
       else expect(n).toBeGreaterThanOrEqual(599)
     })
     expect(result.groupdelay.slice(645).every((d) => Math.abs(d - 7.0) < 1e-9)).toBe(true)
-  })
-
-  it("leaves a filter evaluated in closed form alone, however far down it goes", async () => {
-    // a 4th order highpass at 1 kHz really is 240 dB down at 1 Hz, deeper than
-    // anything blanked above, and its phase there is smooth and readable: no
-    // nulls to rotate through, so nothing for the grid to alias
-    const highpass: Filter = {
-      type: "BiquadCombo",
-      description: null,
-      parameters: { type: "ButterworthHighpass", order: 4, freq: 1000.0 },
-    }
-    const result = await evalFilter(highpass, { samplerate: 48000, channels: 2 })
-    expect(Math.min(...result.magnitude!)).toBeLessThan(-200)
-    expect(result.phase!.every(Number.isFinite)).toBe(true)
-    expect(result.groupdelay!.every(Number.isFinite)).toBe(true)
   })
 })
 

--- a/src/camilladsp/eval/eval.test.ts
+++ b/src/camilladsp/eval/eval.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Behaviour around the evaluator that the golden fixture cannot cover: the
+ * coefficient cache, combining a whole pipeline step, and the samplerate and
+ * channel options a step offers.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { Config, defaultConfig, Filter } from "../config"
+import { clearCoefficientCache, evalFilter, evalFilterStep, intersectFilterOptions, logspace } from "./index"
+
+function convFilter(filename: string): Filter {
+  return {
+    type: "Conv",
+    description: null,
+    parameters: { type: "Raw", filename, format: "TEXT" },
+  }
+}
+
+function gainFilter(gain: number): Filter {
+  return { type: "Gain", description: null, parameters: { gain, scale: "dB" } }
+}
+
+function stubCoefficients(coefficients: number[] = [1.0, 0.0, 0.0, 0.0]) {
+  const fetchMock = vi.fn(async () => new Response(JSON.stringify({ options: [], coefficients })))
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+const filterOptions = { samplerate: 48000, channels: 2, npoints: 32 }
+
+describe("logspace", () => {
+  it("steps by the span divided by the point count, so it stops short of the maximum", () => {
+    const values = logspace(1.0, 1000.0, 3)
+    expect(values.length).toBe(3)
+    expect(values[0]).toBeCloseTo(1.0, 12)
+    expect(values[1]).toBeCloseTo(10.0, 12)
+    expect(values[2]).toBeCloseTo(100.0, 12)
+  })
+})
+
+describe("coefficient cache", () => {
+  beforeEach(() => {
+    clearCoefficientCache()
+    vi.restoreAllMocks()
+  })
+
+  it("fetches a coefficient file once, however often the filter is evaluated", async () => {
+    const fetchMock = stubCoefficients()
+    const filter = convFilter("impulse.raw")
+    await evalFilter(filter, filterOptions)
+    await evalFilter(filter, filterOptions)
+    await evalFilter(filter, filterOptions)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("refetches when the samplerate or the channel count changes", async () => {
+    const fetchMock = stubCoefficients()
+    const filter = convFilter("impulse_$samplerate$.raw")
+    await evalFilter(filter, filterOptions)
+    await evalFilter(filter, { ...filterOptions, samplerate: 96000 })
+    await evalFilter(filter, { ...filterOptions, channels: 4 })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it("does not remember a failed fetch, so the filter can plot once the file appears", async () => {
+    const fetchMock = vi.fn(async () => new Response("no such file", { status: 404 }))
+    vi.stubGlobal("fetch", fetchMock)
+    const filter = convFilter("missing.raw")
+    await expect(evalFilter(filter, filterOptions)).rejects.toThrow()
+    await expect(evalFilter(filter, filterOptions)).rejects.toThrow()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not go to the backend for a Conv that carries its own values", async () => {
+    const fetchMock = stubCoefficients()
+    const filter: Filter = {
+      type: "Conv",
+      description: null,
+      parameters: { type: "Values", values: [1.0, 0.5] },
+    }
+    await evalFilter(filter, filterOptions)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("filter step evaluation", () => {
+  beforeEach(() => {
+    clearCoefficientCache()
+    vi.restoreAllMocks()
+  })
+
+  function configWithStep(filters: { [name: string]: Filter }): Config {
+    const config = defaultConfig()
+    config.filters = filters
+    config.pipeline = [
+      {
+        type: "Filter",
+        channels: [0],
+        names: Object.keys(filters),
+        description: null,
+        bypassed: null,
+      },
+    ]
+    return config
+  }
+
+  it("multiplies the responses of every filter in the step", async () => {
+    const config = configWithStep({ first: gainFilter(-6.0), second: gainFilter(-4.0) })
+    const result = await evalFilterStep(config, 0, filterOptions)
+    for (const magnitude of result.magnitude!) expect(magnitude).toBeCloseTo(-10.0, 9)
+  })
+
+  it("fetches the coefficients of a Conv in the step exactly once", async () => {
+    const fetchMock = stubCoefficients()
+    const config = configWithStep({ conv: convFilter("impulse.raw"), gain: gainFilter(-6.0) })
+    await evalFilterStep(config, 0, filterOptions)
+    await evalFilterStep(config, 0, filterOptions)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("starts at 10 Hz, where a single filter plot starts at 1 Hz", async () => {
+    const config = configWithStep({ gain: gainFilter(0.0) })
+    const step = await evalFilterStep(config, 0, filterOptions)
+    const single = await evalFilter(gainFilter(0.0), filterOptions)
+    expect(step.f[0]).toBeCloseTo(10.0, 12)
+    expect(single.f[0]).toBeCloseTo(1.0, 12)
+  })
+})
+
+describe("filter step options", () => {
+  it("keeps only the combinations every convolution filter can offer", () => {
+    const options = intersectFilterOptions(
+      [
+        [
+          { name: "a_44100.raw", samplerate: 44100 },
+          { name: "a_48000.raw", samplerate: 48000 },
+        ],
+        [{ name: "b_48000.raw", samplerate: 48000 }],
+      ],
+      96000,
+      2,
+    )
+    expect(options).toEqual([{ name: "48000 Hz - 2 Channels", samplerate: 48000, channels: 2 }])
+  })
+
+  it("fills in the step's own samplerate and channels for a filename without tokens", () => {
+    const options = intersectFilterOptions([[{ name: "plain.raw" }]], 44100, 4)
+    expect(options).toEqual([{ name: "44100 Hz - 4 Channels", samplerate: 44100, channels: 4 }])
+  })
+
+  it("has nothing to offer when a step contains no file backed convolution", () => {
+    expect(intersectFilterOptions([], 48000, 2)).toEqual([])
+  })
+})

--- a/src/camilladsp/eval/filters.test.ts
+++ b/src/camilladsp/eval/filters.test.ts
@@ -202,7 +202,7 @@ describe("phase unwrapping", () => {
     }
     const wrapped = truth.map((value) => ((((value + 180.0) % 360.0) + 360.0) % 360.0) - 180.0)
 
-    const ours = unwrapPhase(wrapped)
+    const ours = unwrapPhase(wrapped, 270.0)
     const offset = ours[0] - truth[0]
     ours.forEach((value, n) => expect(Math.abs(value - offset - truth[n])).toBeLessThan(1.0))
 

--- a/src/camilladsp/eval/filters.test.ts
+++ b/src/camilladsp/eval/filters.test.ts
@@ -149,8 +149,9 @@ describe("Conv", () => {
       npoints: 32,
     })
     result.magnitude!.forEach((gain) => expect(gain).toBeCloseTo(0.0, 12))
-    expect(result.impulse).toEqual([1.0])
-    expect(result.time).toEqual([0.0])
+    // the impulse response stays in the typed array it arrives in
+    expect(Array.from(result.impulse!)).toEqual([1.0])
+    expect(Array.from(result.time)).toEqual([0.0])
   })
 
   it("finds the last of several equal peaks", () => {

--- a/src/camilladsp/eval/filters.test.ts
+++ b/src/camilladsp/eval/filters.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Behaviour of the individual filter types.
+ *
+ * Ported from the backend's former `tests/test_filter_evaluation.py`, and
+ * tightened where Python's tolerances were loose. These say what each filter is
+ * supposed to do, in terms a reader can check against CamillaDSP's own filter
+ * sources, rather than pinning a curve.
+ */
+import { describe, expect, it, vi } from "vitest"
+import { Filter } from "../config"
+import { magnitudeDb } from "./complex"
+import { findPeak } from "./conv"
+import { LOUDNESS_LOW_Q } from "./defaults"
+import { complexGain } from "./filters"
+import { clearCoefficientCache, evalFilter, evalFilterStep } from "./index"
+import { FilterEvalError } from "./params"
+import { unwrapPhase } from "./unwrap"
+
+const FS = 48000
+
+function filter(type: string, parameters: Filter["parameters"]): Filter {
+  return { type, description: null, parameters }
+}
+
+/** Magnitude in dB at the given frequencies. */
+function gainAt(f: Filter, freqs: number[], volume = 0.0): number[] {
+  return magnitudeDb(complexGain(f, FS, volume, Float64Array.from(freqs)))
+}
+
+/** Two filters that must produce the same response, compared point by point. */
+function expectSameResponse(a: Filter, b: Filter, volume = 0.0) {
+  const freqs = [10, 50, 100, 500, 1000, 5000, 10000, 20000]
+  const left = gainAt(a, freqs, volume)
+  const right = gainAt(b, freqs, volume)
+  left.forEach((value, n) => expect(value).toBeCloseTo(right[n], 12))
+}
+
+describe("shelving filters reach their gain at one end and unity at the other", () => {
+  it("Lowshelf", () => {
+    const [low, high] = gainAt(filter("Biquad", { type: "Lowshelf", freq: 1000.0, q: 0.707, gain: 6.0 }), [1, 20000])
+    expect(low).toBeCloseTo(6.0, 3)
+    expect(high).toBeCloseTo(0.0, 1)
+  })
+
+  it("Highshelf", () => {
+    const [low, high] = gainAt(filter("Biquad", { type: "Highshelf", freq: 1000.0, q: 0.707, gain: 6.0 }), [1, 20000])
+    expect(low).toBeCloseTo(0.0, 3)
+    expect(high).toBeCloseTo(6.0, 1)
+  })
+})
+
+describe("BiquadCombo", () => {
+  it("a GraphicEqualizer with no gain anywhere is flat", () => {
+    const gains = gainAt(
+      filter("BiquadCombo", { type: "GraphicEqualizer", gains: [0.0, 0.0, 0.0, 0.0] }),
+      [20, 200, 2000, 20000],
+    )
+    gains.forEach((gain) => expect(gain).toBeCloseTo(0.0, 12))
+  })
+
+  it("Tilt splits its gain evenly, low end down and high end up", () => {
+    // the shelves sit at 110 Hz and 3500 Hz with a gentle Q of 0.35, so the
+    // asymptotes are only reached well outside the audio band, and the top one
+    // never quite arrives because the response is squeezed towards Nyquist
+    const [low, high] = gainAt(filter("BiquadCombo", { type: "Tilt", gain: 8.0 }), [0.01, 23000])
+    expect(low).toBeCloseTo(-4.0, 3)
+    expect(high).toBeCloseTo(4.0, 2)
+  })
+
+  it("NPointPeq gives a band the role its position implies", () => {
+    // Only one band has gain, so the others are left out entirely and the
+    // combo must come out identical to that single biquad.
+    const bands = (index: number) =>
+      [0, 1, 2].map((n) => ({ freq: [100.0, 1000.0, 8000.0][n], q: 0.7, gain: n === index ? 5.0 : 0.0 }))
+    const roles = ["Lowshelf", "Peaking", "Highshelf"]
+    roles.forEach((role, index) => {
+      expectSameResponse(
+        filter("BiquadCombo", { type: "NPointPeq", bands: bands(index) }),
+        filter("Biquad", { type: role, freq: [100.0, 1000.0, 8000.0][index], q: 0.7, gain: 5.0 }),
+      )
+    })
+  })
+
+  it("NPointPeq leaves out a band whose gain is below the minimum", () => {
+    const withTinyBand = [
+      { freq: 100.0, q: 0.7, gain: 4.0 },
+      { freq: 1000.0, q: 1.0, gain: 0.0005 },
+      { freq: 8000.0, q: 0.7, gain: -3.0 },
+    ]
+    const withoutIt = [withTinyBand[0], { freq: 1000.0, q: 1.0, gain: 0.0 }, withTinyBand[2]]
+    expectSameResponse(
+      filter("BiquadCombo", { type: "NPointPeq", bands: withTinyBand }),
+      filter("BiquadCombo", { type: "NPointPeq", bands: withoutIt }),
+    )
+  })
+
+  it("an NPointPeq with every band disabled is flat", () => {
+    const bands = [100.0, 1000.0, 8000.0].map((freq) => ({ freq, q: 0.7, gain: 0.0 }))
+    gainAt(filter("BiquadCombo", { type: "NPointPeq", bands }), [20, 1000, 20000]).forEach((gain) =>
+      expect(gain).toBeCloseTo(0.0, 12),
+    )
+  })
+})
+
+describe("Loudness", () => {
+  it("treats an explicit null as not set", () => {
+    // The schema fills the optional parameters in as nulls, which must fall
+    // back to CamillaDSP's defaults exactly like a missing key does.
+    expectSameResponse(
+      filter("Loudness", {
+        reference_level: 0.0,
+        high_freq: null,
+        low_freq: null,
+        high_q: null,
+        low_q: null,
+        high_boost: null,
+        low_boost: null,
+      }),
+      filter("Loudness", { reference_level: 0.0 }),
+      -20.0,
+    )
+  })
+
+  it("uses a default Q equal to the fixed 12 dB/octave slope it replaced", () => {
+    // Before high_q/low_q existed the shelves used a fixed slope. The default
+    // Q has to reproduce it, or every existing config changes shape.
+    for (const gain of [1.0, 5.0, 10.0, 20.0]) {
+      expectSameResponse(
+        filter("Biquad", { type: "Lowshelf", freq: 70.0, q: LOUDNESS_LOW_Q, gain }),
+        filter("Biquad", { type: "Lowshelf", freq: 70.0, slope: 12.0, gain }),
+      )
+    }
+  })
+
+  it("boosts below the reference level and is flat above it", () => {
+    const loudness = filter("Loudness", { reference_level: -20.0 })
+    const boosted = gainAt(loudness, [20], -40.0)[0]
+    const flat = gainAt(loudness, [20], 0.0)[0]
+    expect(boosted).toBeGreaterThan(5.0)
+    expect(flat).toBeCloseTo(0.0, 12)
+  })
+})
+
+describe("Conv", () => {
+  it("a single unity coefficient is flat, and comes back as the impulse response", async () => {
+    const result = await evalFilter(filter("Conv", { type: "Values", values: [1.0] }), {
+      samplerate: FS,
+      channels: 2,
+      npoints: 32,
+    })
+    result.magnitude!.forEach((gain) => expect(gain).toBeCloseTo(0.0, 12))
+    expect(result.impulse).toEqual([1.0])
+    expect(result.time).toEqual([0.0])
+  })
+
+  it("finds the last of several equal peaks", () => {
+    // A tie resolves to the highest index, which is what the delay removal in
+    // the plot expects.
+    expect(findPeak([0.0, 1.0, 0.0, 1.0, 0.0])).toBe(3)
+    expect(findPeak([0.0, 0.5, 1.0, 0.5])).toBe(2)
+    expect(findPeak([1.0, 0.0, -1.0])).toBe(2)
+  })
+})
+
+describe("filter steps", () => {
+  it("reports an unplottable filter instead of leaving it out of the step", async () => {
+    const config = {
+      devices: { samplerate: FS },
+      filters: { odd: filter("SomethingElse", {}) },
+      pipeline: [{ type: "Filter", channels: [0], names: ["odd"], description: null, bypassed: null }],
+    }
+    clearCoefficientCache()
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      evalFilterStep(config as any, 0, { samplerate: FS, channels: 2, npoints: 16 }),
+    ).rejects.toBeInstanceOf(FilterEvalError)
+  })
+
+  it("passes the flat types through without breaking the step", () => {
+    for (const type of ["Volume", "Dither", "Clipper", "LookaheadLimiter"]) {
+      gainAt(filter(type, {}), [20, 1000, 20000]).forEach((gain) => expect(gain).toBeCloseTo(0.0, 12))
+    }
+  })
+
+  it("rejects a biquad subtype it does not know", () => {
+    expect(() => gainAt(filter("Biquad", { type: "NotARealSubtype", freq: 1000.0, q: 1.0 }), [1000])).toThrow(
+      FilterEvalError,
+    )
+  })
+})
+
+describe("phase unwrapping", () => {
+  it("follows a slope steeper than 180 degrees per point", () => {
+    // The predictive term is the whole reason this is not a plain unwrap: it
+    // tracks a phase advancing well past 180 degrees per point, which a naive
+    // one cannot do by construction.
+    const truth: number[] = []
+    let running = 0
+    for (let n = 0; n < 600; n++) {
+      running -= 1.0 + (299.0 * n) / 599
+      truth.push(running)
+    }
+    const wrapped = truth.map((value) => ((((value + 180.0) % 360.0) + 360.0) % 360.0) - 180.0)
+
+    const ours = unwrapPhase(wrapped)
+    const offset = ours[0] - truth[0]
+    ours.forEach((value, n) => expect(Math.abs(value - offset - truth[n])).toBeLessThan(1.0))
+
+    // a naive unwrap, comparing raw steps against half a turn, loses it as
+    // soon as the slope passes 180 degrees per point
+    const naive = [wrapped[0]]
+    let turns = 0
+    for (let n = 1; n < wrapped.length; n++) {
+      const step = wrapped[n] - wrapped[n - 1]
+      if (step > 180.0) turns -= 1
+      else if (step < -180.0) turns += 1
+      naive.push(wrapped[n] + 360.0 * turns)
+    }
+    const naiveOffset = naive[0] - truth[0]
+    const naiveWorst = Math.max(...naive.map((value, n) => Math.abs(value - naiveOffset - truth[n])))
+    expect(naiveWorst).toBeGreaterThan(1000.0)
+  })
+})
+
+describe("demo and error paths", () => {
+  it("surfaces a backend error rather than plotting nothing", async () => {
+    clearCoefficientCache()
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("bad format", { status: 400 })),
+    )
+    await expect(
+      evalFilter(filter("Conv", { type: "Raw", filename: "broken.raw" }), {
+        samplerate: FS,
+        channels: 2,
+        npoints: 16,
+      }),
+    ).rejects.toBeInstanceOf(FilterEvalError)
+    vi.restoreAllMocks()
+  })
+})

--- a/src/camilladsp/eval/filters.ts
+++ b/src/camilladsp/eval/filters.ts
@@ -7,8 +7,8 @@
  * driven from `index.ts`.
  */
 import { Filter } from "../config"
-import { evalBiquad } from "./biquad"
-import { ComplexCurve, constantCurve, multiplyInto, unitCurve, zeroCurve } from "./complex"
+import { BiquadCoefficients, biquadComplexGain, biquadGroupDelay, evalBiquad, evalBiquadGroupDelay } from "./biquad"
+import { applyDelayInto, ComplexCurve, constantCurve, multiplyInto, unitCurve, zeroCurve } from "./complex"
 import {
   GAIN_SCALE,
   GRAPHIC_EQ_FREQ_MAX,
@@ -21,6 +21,7 @@ import {
   LOUDNESS_LOW_Q,
   NPOINT_PEQ_MIN_GAIN,
 } from "./defaults"
+import { addDelayInto, rationalGroupDelay } from "./groupdelay"
 import { FilterEvalError, flag, num, numListOr, numOr, optStr, Params, peqBands, positiveNumOr } from "./params"
 
 /**
@@ -132,7 +133,16 @@ function biquadComboComplexGain(params: Params, fs: number, freq: ArrayLike<numb
   return curve
 }
 
-function loudnessComplexGain(params: Params, fs: number, volume: number, freq: ArrayLike<number>): ComplexCurve {
+function biquadComboGroupDelay(params: Params, fs: number, freq: ArrayLike<number>): Float64Array {
+  const total = new Float64Array(freq.length)
+  for (const section of biquadComboSections(params)) {
+    addDelayInto(total, evalBiquadGroupDelay(section, fs, freq))
+  }
+  return total
+}
+
+/** The two shelves of a Loudness filter, and the flat gain they sit on. */
+function loudnessDesign(params: Params, volume: number): { midGain: number; sections: Params[] } {
   const relativeVolume = volume - num(params, "reference_level")
   let relativeBoost = -relativeVolume / 20.0
   if (relativeBoost > 1.0) relativeBoost = 1.0
@@ -157,9 +167,23 @@ function loudnessComplexGain(params: Params, fs: number, volume: number, freq: A
       type: "Highshelf",
     },
   ]
+  return { midGain, sections }
+}
+
+function loudnessComplexGain(params: Params, fs: number, volume: number, freq: ArrayLike<number>): ComplexCurve {
+  const { midGain, sections } = loudnessDesign(params, volume)
   const curve = constantCurve(freq.length, midGain)
   for (const section of sections) multiplyInto(curve, evalBiquad(section, fs, freq))
   return curve
+}
+
+function loudnessGroupDelay(params: Params, fs: number, volume: number, freq: ArrayLike<number>): Float64Array {
+  // the mid gain is a flat scaling, which delays nothing
+  const total = new Float64Array(freq.length)
+  for (const section of loudnessDesign(params, volume).sections) {
+    addDelayInto(total, evalBiquadGroupDelay(section, fs, freq))
+  }
+  return total
 }
 
 function gainComplexGain(params: Params, freq: ArrayLike<number>): ComplexCurve {
@@ -190,84 +214,58 @@ function delayInSamples(params: Params, fs: number): number {
   }
 }
 
-function delayComplexGain(params: Params, fs: number, freq: ArrayLike<number>): ComplexCurve {
+/**
+ * A delay as the DSP builds it: a whole number of samples, and for a subsample
+ * delay an allpass section carrying the fraction.
+ */
+function delayDesign(params: Params, fs: number): { allpass?: BiquadCoefficients; fullSamples: number } {
   const delaySamples = delayInSamples(params, fs)
   // a delay this short cannot be resolved by the allpass, and the DSP falls
   // back to a whole number of samples
   const subsample = flag(params, "subsample") && delaySamples >= 0.1
+  if (!subsample) return { fullSamples: Math.round(delaySamples) }
 
-  let curve: ComplexCurve
-  let fullSamples: number
-  if (subsample) {
-    let full = Math.floor(delaySamples)
-    let fraction = delaySamples - full
-    let a1: number
-    let a2: number
-    let b0: number
-    let b1: number
-    let b2: number
-    if (delaySamples < 1.1) {
-      full = 0
-      fraction = delaySamples
-      a1 = (1.0 - fraction) / (1.0 + fraction)
-      a2 = 0.0
-      b0 = (1.0 - fraction) / (1.0 + fraction)
-      b1 = 1.0
-      b2 = 0.0
-    } else {
-      // the second order allpass needs a fraction of at least about one
-      // sample, so borrow whole samples from the integer part until it does
-      full -= 1.0
-      fraction += 1.0
-      if (fraction < 1.1) {
-        full -= 1.0
-        fraction += 1.0
-      }
-      const coeff1 = (2.0 * (2.0 - fraction)) / (1.0 + fraction)
-      const coeff2 = (((2.0 - fraction) / (2.0 + fraction)) * (1.0 - fraction)) / (1.0 + fraction)
-      a1 = coeff1
-      a2 = coeff2
-      b0 = coeff2
-      b1 = coeff1
-      b2 = 1.0
-    }
-    fullSamples = full
-    curve = zeroCurve(freq.length)
-    for (let n = 0; n < freq.length; n++) {
-      const w = (2 * Math.PI * freq[n]) / fs
-      const c1 = Math.cos(w)
-      const s1 = -Math.sin(w)
-      const c2 = Math.cos(2 * w)
-      const s2 = -Math.sin(2 * w)
-      const nre = b0 + b1 * c1 + b2 * c2
-      const nim = b1 * s1 + b2 * s2
-      const dre = 1.0 + a1 * c1 + a2 * c2
-      const dim = a1 * s1 + a2 * s2
-      const denom = dre * dre + dim * dim
-      curve.re[n] = (nre * dre + nim * dim) / denom
-      curve.im[n] = (nim * dre - nre * dim) / denom
-    }
-  } else {
-    fullSamples = Math.round(delaySamples)
-    curve = unitCurve(freq.length)
+  let full = Math.floor(delaySamples)
+  let fraction = delaySamples - full
+  if (delaySamples < 1.1) {
+    full = 0
+    fraction = delaySamples
+    const coeff = (1.0 - fraction) / (1.0 + fraction)
+    return { allpass: { a1: coeff, a2: 0.0, b0: coeff, b1: 1.0, b2: 0.0 }, fullSamples: full }
   }
+  // the second order allpass needs a fraction of at least about one sample, so
+  // borrow whole samples from the integer part until it does
+  full -= 1.0
+  fraction += 1.0
+  if (fraction < 1.1) {
+    full -= 1.0
+    fraction += 1.0
+  }
+  const coeff1 = (2.0 * (2.0 - fraction)) / (1.0 + fraction)
+  const coeff2 = (((2.0 - fraction) / (2.0 + fraction)) * (1.0 - fraction)) / (1.0 + fraction)
+  return { allpass: { a1: coeff1, a2: coeff2, b0: coeff2, b1: coeff1, b2: 1.0 }, fullSamples: full }
+}
 
-  const delaySeconds = fullSamples / fs
-  for (let n = 0; n < freq.length; n++) {
-    const angle = -2.0 * Math.PI * freq[n] * delaySeconds
-    const wr = Math.cos(angle)
-    const wi = Math.sin(angle)
-    const re = curve.re[n] * wr - curve.im[n] * wi
-    const im = curve.re[n] * wi + curve.im[n] * wr
-    curve.re[n] = re
-    curve.im[n] = im
-  }
+function delayComplexGain(params: Params, fs: number, freq: ArrayLike<number>): ComplexCurve {
+  const { allpass, fullSamples } = delayDesign(params, fs)
+  const curve = allpass === undefined ? unitCurve(freq.length) : biquadComplexGain(allpass, fs, freq)
+  applyDelayInto(curve, fullSamples / fs, freq)
   return curve
 }
 
+function delayGroupDelay(params: Params, fs: number, freq: ArrayLike<number>): Float64Array {
+  const { allpass, fullSamples } = delayDesign(params, fs)
+  const total = allpass === undefined ? new Float64Array(freq.length) : biquadGroupDelay(allpass, fs, freq)
+  for (let n = 0; n < total.length; n++) total[n] += fullSamples
+  return total
+}
+
+function diffEqCoefficients(params: Params): { a: number[]; b: number[] } {
+  return { a: numListOr(params, "a", [1.0]), b: numListOr(params, "b", [1.0]) }
+}
+
 function diffEqComplexGain(params: Params, fs: number, freq: ArrayLike<number>): ComplexCurve {
-  const a = numListOr(params, "a", [1.0])
-  const b = numListOr(params, "b", [1.0])
+  const { a, b } = diffEqCoefficients(params)
   const curve = zeroCurve(freq.length)
   for (let n = 0; n < freq.length; n++) {
     const w = (2 * Math.PI * freq[n]) / fs
@@ -288,6 +286,44 @@ function diffEqComplexGain(params: Params, fs: number, freq: ArrayLike<number>):
     curve.im[n] = (nim * dre - nre * dim) / denom
   }
   return curve
+}
+
+/**
+ * The group delay in samples of any filter except Conv, which needs
+ * coefficients and is taken from `convGroupDelay` instead.
+ *
+ * Every type here is a cascade of rational sections, so each one is the exact
+ * `Re(G/H)` of its own coefficients, summed along the cascade. See
+ * `groupdelay.ts` for why that is not read off the phase.
+ */
+export function groupDelaySamples(
+  filterconf: Filter,
+  fs: number,
+  volume: number,
+  freq: ArrayLike<number>,
+): Float64Array {
+  const params = (filterconf.parameters ?? {}) as Params
+  switch (filterconf.type) {
+    case "Biquad":
+      return evalBiquadGroupDelay(params, fs, freq)
+    case "BiquadCombo":
+      return biquadComboGroupDelay(params, fs, freq)
+    case "DiffEq": {
+      const { a, b } = diffEqCoefficients(params)
+      return rationalGroupDelay(b, a, fs, freq)
+    }
+    case "Delay":
+      return delayGroupDelay(params, fs, freq)
+    case "Loudness":
+      return loudnessGroupDelay(params, fs, volume, freq)
+    default:
+      // a Gain is a flat scaling, and the flat types pass audio through as it
+      // stands, so neither delays anything
+      if (filterconf.type === "Gain" || FLAT_FILTER_TYPES.includes(filterconf.type)) {
+        return new Float64Array(freq.length)
+      }
+      throw new FilterEvalError(`Unknown filter type ${filterconf.type}`)
+  }
 }
 
 /**

--- a/src/camilladsp/eval/filters.ts
+++ b/src/camilladsp/eval/filters.ts
@@ -1,0 +1,316 @@
+/**
+ * Transfer functions for every filter type, ported from the GUI backend's
+ * former `backend/dsp/filters.py`.
+ *
+ * Conv is the one type that is not here: it needs coefficients, which come
+ * either from the config or from the backend, so it lives in `conv.ts` and is
+ * driven from `index.ts`.
+ */
+import { Filter } from "../config"
+import { evalBiquad } from "./biquad"
+import { ComplexCurve, constantCurve, multiplyInto, unitCurve, zeroCurve } from "./complex"
+import {
+  GAIN_SCALE,
+  GRAPHIC_EQ_FREQ_MAX,
+  GRAPHIC_EQ_FREQ_MIN,
+  LOUDNESS_HIGH_BOOST,
+  LOUDNESS_HIGH_FREQ,
+  LOUDNESS_HIGH_Q,
+  LOUDNESS_LOW_BOOST,
+  LOUDNESS_LOW_FREQ,
+  LOUDNESS_LOW_Q,
+  NPOINT_PEQ_MIN_GAIN,
+} from "./defaults"
+import { FilterEvalError, flag, num, numListOr, numOr, optStr, Params, peqBands, positiveNumOr } from "./params"
+
+/**
+ * Filter types that pass audio through unchanged as far as a frequency
+ * response plot is concerned. They still have to be handled, so that a step
+ * containing one plots the rest of the step instead of failing.
+ */
+export const FLAT_FILTER_TYPES = ["Volume", "Dither", "Clipper", "LookaheadLimiter"]
+
+/** The Q values of the second order sections of a Butterworth filter. */
+function butterworthQ(order: number): number[] {
+  const odd = order % 2 > 0
+  const nSecondOrder = Math.floor(order / 2.0)
+  const qvalues: number[] = []
+  for (let n = 0; n < nSecondOrder; n++) {
+    qvalues.push(1 / (2.0 * Math.sin((Math.PI / order) * (n + 1 / 2))))
+  }
+  // a negative Q is the sentinel for the leftover first order section of an
+  // odd order filter, which has no Q of its own
+  if (odd) qvalues.push(-1.0)
+  return qvalues
+}
+
+/** The biquads a BiquadCombo expands into. */
+function biquadComboSections(params: Params): Params[] {
+  const ftype = params.type
+  switch (ftype) {
+    case "LinkwitzRileyHighpass":
+    case "LinkwitzRileyLowpass":
+    case "ButterworthHighpass":
+    case "ButterworthLowpass": {
+      const order = num(params, "order")
+      const freq = num(params, "freq")
+      const lowpass = ftype === "LinkwitzRileyLowpass" || ftype === "ButterworthLowpass"
+      const typeSecondOrder = lowpass ? "Lowpass" : "Highpass"
+      const typeFirstOrder = lowpass ? "LowpassFO" : "HighpassFO"
+      let qvalues: number[]
+      if (ftype === "LinkwitzRileyHighpass" || ftype === "LinkwitzRileyLowpass") {
+        // A Linkwitz-Riley filter is two cascaded Butterworths of half the
+        // order. When that half order is itself odd, its two first order
+        // sections combine into a single second order section with Q = 0.5.
+        let half = butterworthQ(order / 2)
+        if ((order / 2) % 2 > 0) {
+          half = half.slice(0, -1)
+          qvalues = half.concat(half, [0.5])
+        } else {
+          qvalues = half.concat(half)
+        }
+      } else {
+        qvalues = butterworthQ(order)
+      }
+      const sections: Params[] = []
+      for (const q of qvalues) {
+        // a first order section has no Q of its own
+        if (q < 0) sections.push({ freq, type: typeFirstOrder })
+        else sections.push({ freq, q, type: typeSecondOrder })
+      }
+      return sections
+    }
+    case "NPointPeq": {
+      // The role of a band follows its position: the first is a low shelf, the
+      // last a high shelf, and the ones between are peaking filters. A band
+      // with no significant gain does nothing, so the DSP leaves it out; skip
+      // it here too so the plot matches.
+      const bands = peqBands(params, "bands")
+      const last = bands.length - 1
+      const sections: Params[] = []
+      bands.forEach((band, n) => {
+        if (Math.abs(band.gain) <= NPOINT_PEQ_MIN_GAIN) return
+        const type = n === 0 ? "Lowshelf" : n === last ? "Highshelf" : "Peaking"
+        sections.push({ freq: band.freq, q: band.q, gain: band.gain, type })
+      })
+      return sections
+    }
+    case "GraphicEqualizer": {
+      const gains = numListOr(params, "gains", [])
+      const bands = gains.length
+      // zero is invalid here, the DSP rejects it, and must fall back to the
+      // default rather than reach log2
+      const fMinLog = Math.log2(positiveNumOr(params, "freq_min", GRAPHIC_EQ_FREQ_MIN))
+      const fMaxLog = Math.log2(positiveNumOr(params, "freq_max", GRAPHIC_EQ_FREQ_MAX))
+      const bandwidth = (fMaxLog - fMinLog) / bands
+      const sections: Params[] = []
+      gains.forEach((gain, band) => {
+        if (Math.abs(gain) > 0.01) {
+          const freqLog = fMinLog + (band + 0.5) * bandwidth
+          sections.push({ freq: Math.pow(2.0, freqLog), bandwidth, gain, type: "Peaking" })
+        }
+      })
+      return sections
+    }
+    case "Tilt": {
+      const gain = num(params, "gain")
+      return [
+        { freq: 110.0, q: 0.35, gain: -gain / 2.0, type: "Lowshelf" },
+        { freq: 3500.0, q: 0.35, gain: gain / 2.0, type: "Highshelf" },
+      ]
+    }
+    default:
+      throw new FilterEvalError(`Unknown BiquadCombo subtype ${String(ftype)}`)
+  }
+}
+
+function biquadComboComplexGain(params: Params, fs: number, freq: ArrayLike<number>): ComplexCurve {
+  const curve = unitCurve(freq.length)
+  for (const section of biquadComboSections(params)) {
+    multiplyInto(curve, evalBiquad(section, fs, freq))
+  }
+  return curve
+}
+
+function loudnessComplexGain(params: Params, fs: number, volume: number, freq: ArrayLike<number>): ComplexCurve {
+  const relativeVolume = volume - num(params, "reference_level")
+  let relativeBoost = -relativeVolume / 20.0
+  if (relativeBoost > 1.0) relativeBoost = 1.0
+  else if (relativeBoost < 0.0) relativeBoost = 0.0
+  const highBoost = relativeBoost * numOr(params, "high_boost", LOUDNESS_HIGH_BOOST)
+  const lowBoost = relativeBoost * numOr(params, "low_boost", LOUDNESS_LOW_BOOST)
+  const midGain = flag(params, "attenuate_mid") ? Math.pow(10.0, -Math.max(highBoost, lowBoost) / 20.0) : 1.0
+
+  // The shelves take a Q, as in the DSP. The default Q is equivalent to the
+  // fixed 12 dB/octave slope used before these parameters existed.
+  const sections: Params[] = [
+    {
+      freq: numOr(params, "low_freq", LOUDNESS_LOW_FREQ),
+      q: numOr(params, "low_q", LOUDNESS_LOW_Q),
+      gain: lowBoost,
+      type: "Lowshelf",
+    },
+    {
+      freq: numOr(params, "high_freq", LOUDNESS_HIGH_FREQ),
+      q: numOr(params, "high_q", LOUDNESS_HIGH_Q),
+      gain: highBoost,
+      type: "Highshelf",
+    },
+  ]
+  const curve = constantCurve(freq.length, midGain)
+  for (const section of sections) multiplyInto(curve, evalBiquad(section, fs, freq))
+  return curve
+}
+
+function gainComplexGain(params: Params, freq: ArrayLike<number>): ComplexCurve {
+  const sign = flag(params, "inverted") ? -1.0 : 1.0
+  const gain = num(params, "gain")
+  const scale = optStr(params, "scale") ?? GAIN_SCALE
+  const value = scale === "dB" ? Math.pow(10.0, gain / 20.0) * sign : gain * sign
+  return constantCurve(freq.length, value)
+}
+
+/** The delay in samples, in whichever unit the config gives it. */
+function delayInSamples(params: Params, fs: number): number {
+  const delay = num(params, "delay")
+  const unit = optStr(params, "delay_unit") ?? "ms"
+  switch (unit) {
+    case "ms":
+      return (delay / 1000.0) * fs
+    case "us":
+      return (delay / 1000000.0) * fs
+    case "s":
+      return delay * fs
+    case "mm":
+      return ((delay / 1000.0) * fs) / 343.0
+    case "samples":
+      return delay
+    default:
+      throw new FilterEvalError(`Unknown delay unit ${unit}`)
+  }
+}
+
+function delayComplexGain(params: Params, fs: number, freq: ArrayLike<number>): ComplexCurve {
+  const delaySamples = delayInSamples(params, fs)
+  // a delay this short cannot be resolved by the allpass, and the DSP falls
+  // back to a whole number of samples
+  const subsample = flag(params, "subsample") && delaySamples >= 0.1
+
+  let curve: ComplexCurve
+  let fullSamples: number
+  if (subsample) {
+    let full = Math.floor(delaySamples)
+    let fraction = delaySamples - full
+    let a1: number
+    let a2: number
+    let b0: number
+    let b1: number
+    let b2: number
+    if (delaySamples < 1.1) {
+      full = 0
+      fraction = delaySamples
+      a1 = (1.0 - fraction) / (1.0 + fraction)
+      a2 = 0.0
+      b0 = (1.0 - fraction) / (1.0 + fraction)
+      b1 = 1.0
+      b2 = 0.0
+    } else {
+      // the second order allpass needs a fraction of at least about one
+      // sample, so borrow whole samples from the integer part until it does
+      full -= 1.0
+      fraction += 1.0
+      if (fraction < 1.1) {
+        full -= 1.0
+        fraction += 1.0
+      }
+      const coeff1 = (2.0 * (2.0 - fraction)) / (1.0 + fraction)
+      const coeff2 = (((2.0 - fraction) / (2.0 + fraction)) * (1.0 - fraction)) / (1.0 + fraction)
+      a1 = coeff1
+      a2 = coeff2
+      b0 = coeff2
+      b1 = coeff1
+      b2 = 1.0
+    }
+    fullSamples = full
+    curve = zeroCurve(freq.length)
+    for (let n = 0; n < freq.length; n++) {
+      const w = (2 * Math.PI * freq[n]) / fs
+      const c1 = Math.cos(w)
+      const s1 = -Math.sin(w)
+      const c2 = Math.cos(2 * w)
+      const s2 = -Math.sin(2 * w)
+      const nre = b0 + b1 * c1 + b2 * c2
+      const nim = b1 * s1 + b2 * s2
+      const dre = 1.0 + a1 * c1 + a2 * c2
+      const dim = a1 * s1 + a2 * s2
+      const denom = dre * dre + dim * dim
+      curve.re[n] = (nre * dre + nim * dim) / denom
+      curve.im[n] = (nim * dre - nre * dim) / denom
+    }
+  } else {
+    fullSamples = Math.round(delaySamples)
+    curve = unitCurve(freq.length)
+  }
+
+  const delaySeconds = fullSamples / fs
+  for (let n = 0; n < freq.length; n++) {
+    const angle = -2.0 * Math.PI * freq[n] * delaySeconds
+    const wr = Math.cos(angle)
+    const wi = Math.sin(angle)
+    const re = curve.re[n] * wr - curve.im[n] * wi
+    const im = curve.re[n] * wi + curve.im[n] * wr
+    curve.re[n] = re
+    curve.im[n] = im
+  }
+  return curve
+}
+
+function diffEqComplexGain(params: Params, fs: number, freq: ArrayLike<number>): ComplexCurve {
+  const a = numListOr(params, "a", [1.0])
+  const b = numListOr(params, "b", [1.0])
+  const curve = zeroCurve(freq.length)
+  for (let n = 0; n < freq.length; n++) {
+    const w = (2 * Math.PI * freq[n]) / fs
+    let nre = 0.0
+    let nim = 0.0
+    for (let k = 0; k < b.length; k++) {
+      nre += b[k] * Math.cos(k * w)
+      nim -= b[k] * Math.sin(k * w)
+    }
+    let dre = 0.0
+    let dim = 0.0
+    for (let k = 0; k < a.length; k++) {
+      dre += a[k] * Math.cos(k * w)
+      dim -= a[k] * Math.sin(k * w)
+    }
+    const denom = dre * dre + dim * dim
+    curve.re[n] = (nre * dre + nim * dim) / denom
+    curve.im[n] = (nim * dre - nre * dim) / denom
+  }
+  return curve
+}
+
+/**
+ * The transfer function of any filter except Conv, which needs coefficients
+ * and is evaluated from `index.ts` instead.
+ */
+export function complexGain(filterconf: Filter, fs: number, volume: number, freq: ArrayLike<number>): ComplexCurve {
+  const params = (filterconf.parameters ?? {}) as Params
+  switch (filterconf.type) {
+    case "Biquad":
+      return evalBiquad(params, fs, freq)
+    case "BiquadCombo":
+      return biquadComboComplexGain(params, fs, freq)
+    case "DiffEq":
+      return diffEqComplexGain(params, fs, freq)
+    case "Delay":
+      return delayComplexGain(params, fs, freq)
+    case "Gain":
+      return gainComplexGain(params, freq)
+    case "Loudness":
+      return loudnessComplexGain(params, fs, volume, freq)
+    default:
+      if (FLAT_FILTER_TYPES.includes(filterconf.type)) return unitCurve(freq.length)
+      throw new FilterEvalError(`Unknown filter type ${filterconf.type}`)
+  }
+}

--- a/src/camilladsp/eval/fixtures/variants.json
+++ b/src/camilladsp/eval/fixtures/variants.json
@@ -1,0 +1,1199 @@
+{
+ "generated_by": "camillagui-backend/tools/dump_filter_variants.py",
+ "volume": -45.0,
+ "variants": [
+  {
+   "id": "Biquad-Lowpass-required",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "q": 1.0,
+     "type": "Lowpass"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Lowpass-required-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "q": 1.0,
+     "type": "Lowpass"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Highpass-required",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "q": 1.0,
+     "type": "Highpass"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Highpass-required-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "q": 1.0,
+     "type": "Highpass"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Bandpass-required+q",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "q": 1.0,
+     "type": "Bandpass"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Bandpass-required+q-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "q": 1.0,
+     "type": "Bandpass"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Bandpass-required+bandwidth",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "bandwidth": 1.0,
+     "type": "Bandpass"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Bandpass-required+bandwidth-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "bandwidth": 1.0,
+     "type": "Bandpass"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Notch-required+q",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "q": 1.0,
+     "type": "Notch"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Notch-required+q-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "q": 1.0,
+     "type": "Notch"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Notch-required+bandwidth",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "bandwidth": 1.0,
+     "type": "Notch"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Notch-required+bandwidth-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "bandwidth": 1.0,
+     "type": "Notch"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-GeneralNotch-required",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq_p": 2000.0,
+     "freq_z": 1000.0,
+     "q_p": 2.0,
+     "type": "GeneralNotch"
+    }
+   }
+  },
+  {
+   "id": "Biquad-GeneralNotch-required-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq_p": 2000.0,
+     "freq_z": 1000.0,
+     "q_p": 2.0,
+     "type": "GeneralNotch",
+     "normalize_at_dc": null
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-GeneralNotch-all",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq_p": 2000.0,
+     "q_p": 2.0,
+     "freq_z": 1000.0,
+     "normalize_at_dc": false,
+     "type": "GeneralNotch"
+    }
+   }
+  },
+  {
+   "id": "Biquad-GeneralNotch-all-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq_p": 2000.0,
+     "q_p": 2.0,
+     "freq_z": 1000.0,
+     "normalize_at_dc": false,
+     "type": "GeneralNotch"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Allpass-required+q",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "q": 1.0,
+     "type": "Allpass"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Allpass-required+q-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "q": 1.0,
+     "type": "Allpass"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Allpass-required+bandwidth",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "bandwidth": 1.0,
+     "type": "Allpass"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Allpass-required+bandwidth-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "bandwidth": 1.0,
+     "type": "Allpass"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-LowpassFO-required",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "type": "LowpassFO"
+    }
+   }
+  },
+  {
+   "id": "Biquad-LowpassFO-required-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "type": "LowpassFO"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-HighpassFO-required",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "type": "HighpassFO"
+    }
+   }
+  },
+  {
+   "id": "Biquad-HighpassFO-required-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "type": "HighpassFO"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-AllpassFO-required",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "type": "AllpassFO"
+    }
+   }
+  },
+  {
+   "id": "Biquad-AllpassFO-required-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "type": "AllpassFO"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Peaking-required+q",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "q": 1.0,
+     "type": "Peaking"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Peaking-required+q-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "q": 1.0,
+     "type": "Peaking"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Peaking-required+bandwidth",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "bandwidth": 1.0,
+     "type": "Peaking"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Peaking-required+bandwidth-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "bandwidth": 1.0,
+     "type": "Peaking"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Lowshelf-required+q",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "q": 1.0,
+     "type": "Lowshelf"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Lowshelf-required+q-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "q": 1.0,
+     "type": "Lowshelf"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Lowshelf-required+slope",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "slope": 6.0,
+     "type": "Lowshelf"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Lowshelf-required+slope-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "slope": 6.0,
+     "type": "Lowshelf"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Highshelf-required+q",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "q": 1.0,
+     "type": "Highshelf"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Highshelf-required+q-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "q": 1.0,
+     "type": "Highshelf"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Highshelf-required+slope",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "slope": 6.0,
+     "type": "Highshelf"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Highshelf-required+slope-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "slope": 6.0,
+     "type": "Highshelf"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-LowshelfFO-required",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "type": "LowshelfFO"
+    }
+   }
+  },
+  {
+   "id": "Biquad-LowshelfFO-required-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "type": "LowshelfFO"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-HighshelfFO-required",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "type": "HighshelfFO"
+    }
+   }
+  },
+  {
+   "id": "Biquad-HighshelfFO-required-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq": 1000.0,
+     "gain": 3.0,
+     "type": "HighshelfFO"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-LinkwitzTransform-required",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq_act": 60.0,
+     "q_act": 0.7,
+     "freq_target": 30.0,
+     "q_target": 0.8,
+     "type": "LinkwitzTransform"
+    }
+   }
+  },
+  {
+   "id": "Biquad-LinkwitzTransform-required-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "freq_act": 60.0,
+     "q_act": 0.7,
+     "freq_target": 30.0,
+     "q_target": 0.8,
+     "type": "LinkwitzTransform"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Biquad-Free-required",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "a1": -0.2,
+     "a2": 0.1,
+     "b0": 0.9,
+     "b1": 0.1,
+     "b2": -0.05,
+     "type": "Free"
+    }
+   }
+  },
+  {
+   "id": "Biquad-Free-required-defaults",
+   "filter": {
+    "type": "Biquad",
+    "parameters": {
+     "a1": -0.2,
+     "a2": 0.1,
+     "b0": 0.9,
+     "b1": 0.1,
+     "b2": -0.05,
+     "type": "Free"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "BiquadCombo-ButterworthHighpass-required",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "freq": 1000.0,
+     "order": 4,
+     "type": "ButterworthHighpass"
+    }
+   }
+  },
+  {
+   "id": "BiquadCombo-ButterworthHighpass-required-defaults",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "freq": 1000.0,
+     "order": 4,
+     "type": "ButterworthHighpass"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "BiquadCombo-ButterworthLowpass-required",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "freq": 1000.0,
+     "order": 4,
+     "type": "ButterworthLowpass"
+    }
+   }
+  },
+  {
+   "id": "BiquadCombo-ButterworthLowpass-required-defaults",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "freq": 1000.0,
+     "order": 4,
+     "type": "ButterworthLowpass"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "BiquadCombo-LinkwitzRileyHighpass-required",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "freq": 1000.0,
+     "order": 4,
+     "type": "LinkwitzRileyHighpass"
+    }
+   }
+  },
+  {
+   "id": "BiquadCombo-LinkwitzRileyHighpass-required-defaults",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "freq": 1000.0,
+     "order": 4,
+     "type": "LinkwitzRileyHighpass"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "BiquadCombo-LinkwitzRileyLowpass-required",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "freq": 1000.0,
+     "order": 4,
+     "type": "LinkwitzRileyLowpass"
+    }
+   }
+  },
+  {
+   "id": "BiquadCombo-LinkwitzRileyLowpass-required-defaults",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "freq": 1000.0,
+     "order": 4,
+     "type": "LinkwitzRileyLowpass"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "BiquadCombo-Tilt-required",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "gain": 3.0,
+     "type": "Tilt"
+    }
+   }
+  },
+  {
+   "id": "BiquadCombo-Tilt-required-defaults",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "gain": 3.0,
+     "type": "Tilt"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "BiquadCombo-NPointPeq-required",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "bands": [
+      {
+       "freq": 100.0,
+       "q": 0.7,
+       "gain": 3.0
+      },
+      {
+       "freq": 1000.0,
+       "q": 1.0,
+       "gain": -2.0
+      },
+      {
+       "freq": 8000.0,
+       "q": 0.7,
+       "gain": 3.0
+      }
+     ],
+     "type": "NPointPeq"
+    }
+   }
+  },
+  {
+   "id": "BiquadCombo-NPointPeq-required-defaults",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "bands": [
+      {
+       "freq": 100.0,
+       "q": 0.7,
+       "gain": 3.0
+      },
+      {
+       "freq": 1000.0,
+       "q": 1.0,
+       "gain": -2.0
+      },
+      {
+       "freq": 8000.0,
+       "q": 0.7,
+       "gain": 3.0
+      }
+     ],
+     "type": "NPointPeq"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "BiquadCombo-GraphicEqualizer-required",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "gains": [
+      0.0,
+      3.0,
+      0.0
+     ],
+     "type": "GraphicEqualizer"
+    }
+   }
+  },
+  {
+   "id": "BiquadCombo-GraphicEqualizer-required-defaults",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "gains": [
+      0.0,
+      3.0,
+      0.0
+     ],
+     "type": "GraphicEqualizer",
+     "freq_min": null,
+     "freq_max": null
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "BiquadCombo-GraphicEqualizer-all",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "freq_min": 20.0,
+     "freq_max": 20000.0,
+     "gains": [
+      0.0,
+      3.0,
+      0.0
+     ],
+     "type": "GraphicEqualizer"
+    }
+   }
+  },
+  {
+   "id": "BiquadCombo-GraphicEqualizer-all-defaults",
+   "filter": {
+    "type": "BiquadCombo",
+    "parameters": {
+     "freq_min": 20.0,
+     "freq_max": 20000.0,
+     "gains": [
+      0.0,
+      3.0,
+      0.0
+     ],
+     "type": "GraphicEqualizer"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Conv-Values-required",
+   "filter": {
+    "type": "Conv",
+    "parameters": {
+     "values": [
+      1.0,
+      0.5
+     ],
+     "type": "Values"
+    }
+   }
+  },
+  {
+   "id": "Conv-Values-required-defaults",
+   "filter": {
+    "type": "Conv",
+    "parameters": {
+     "values": [
+      1.0,
+      0.5
+     ],
+     "type": "Values"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Conv-Dummy-required",
+   "filter": {
+    "type": "Conv",
+    "parameters": {
+     "length": 1024,
+     "type": "Dummy"
+    }
+   }
+  },
+  {
+   "id": "Conv-Dummy-required-defaults",
+   "filter": {
+    "type": "Conv",
+    "parameters": {
+     "length": 1024,
+     "type": "Dummy"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Dither-Flat-required",
+   "filter": {
+    "type": "Dither",
+    "parameters": {
+     "amplitude": 0.5,
+     "bits": 16,
+     "type": "Flat"
+    }
+   }
+  },
+  {
+   "id": "Dither-Flat-required-defaults",
+   "filter": {
+    "type": "Dither",
+    "parameters": {
+     "amplitude": 0.5,
+     "bits": 16,
+     "type": "Flat"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Gain-None-required",
+   "filter": {
+    "type": "Gain",
+    "parameters": {
+     "gain": 3.0
+    }
+   }
+  },
+  {
+   "id": "Gain-None-required-defaults",
+   "filter": {
+    "type": "Gain",
+    "parameters": {
+     "gain": 3.0,
+     "inverted": null,
+     "mute": null,
+     "scale": null
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Gain-None-all",
+   "filter": {
+    "type": "Gain",
+    "parameters": {
+     "gain": 3.0,
+     "inverted": false,
+     "mute": false,
+     "scale": "dB"
+    }
+   }
+  },
+  {
+   "id": "Gain-None-all-defaults",
+   "filter": {
+    "type": "Gain",
+    "parameters": {
+     "gain": 3.0,
+     "inverted": false,
+     "mute": false,
+     "scale": "dB"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Delay-None-required",
+   "filter": {
+    "type": "Delay",
+    "parameters": {
+     "delay": 3.0,
+     "delay_unit": "ms"
+    }
+   }
+  },
+  {
+   "id": "Delay-None-required-defaults",
+   "filter": {
+    "type": "Delay",
+    "parameters": {
+     "delay": 3.0,
+     "delay_unit": "ms",
+     "subsample": null
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Delay-None-all",
+   "filter": {
+    "type": "Delay",
+    "parameters": {
+     "delay": 3.0,
+     "delay_unit": "ms",
+     "subsample": false
+    }
+   }
+  },
+  {
+   "id": "Delay-None-all-defaults",
+   "filter": {
+    "type": "Delay",
+    "parameters": {
+     "delay": 3.0,
+     "delay_unit": "ms",
+     "subsample": false
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Volume-None-required",
+   "filter": {
+    "type": "Volume",
+    "parameters": {
+     "fader": "Aux1"
+    }
+   }
+  },
+  {
+   "id": "Volume-None-required-defaults",
+   "filter": {
+    "type": "Volume",
+    "parameters": {
+     "fader": "Aux1",
+     "ramp_time_ms": null,
+     "limit": null
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Volume-None-all",
+   "filter": {
+    "type": "Volume",
+    "parameters": {
+     "ramp_time_ms": 400.0,
+     "limit": -10.0,
+     "fader": "Aux1"
+    }
+   }
+  },
+  {
+   "id": "Volume-None-all-defaults",
+   "filter": {
+    "type": "Volume",
+    "parameters": {
+     "ramp_time_ms": 400.0,
+     "limit": -10.0,
+     "fader": "Aux1"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Loudness-None-required",
+   "filter": {
+    "type": "Loudness",
+    "parameters": {
+     "reference_level": -25.0
+    }
+   }
+  },
+  {
+   "id": "Loudness-None-required-defaults",
+   "filter": {
+    "type": "Loudness",
+    "parameters": {
+     "reference_level": -25.0,
+     "high_boost": null,
+     "low_boost": null,
+     "high_freq": null,
+     "low_freq": null,
+     "high_q": null,
+     "low_q": null,
+     "fader": null,
+     "attenuate_mid": null
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Loudness-None-all",
+   "filter": {
+    "type": "Loudness",
+    "parameters": {
+     "reference_level": -25.0,
+     "high_boost": 10.0,
+     "low_boost": 10.0,
+     "high_freq": 3500.0,
+     "low_freq": 70.0,
+     "high_q": 0.7,
+     "low_q": 0.7,
+     "fader": "Aux1",
+     "attenuate_mid": false
+    }
+   }
+  },
+  {
+   "id": "Loudness-None-all-defaults",
+   "filter": {
+    "type": "Loudness",
+    "parameters": {
+     "reference_level": -25.0,
+     "high_boost": 10.0,
+     "low_boost": 10.0,
+     "high_freq": 3500.0,
+     "low_freq": 70.0,
+     "high_q": 0.7,
+     "low_q": 0.7,
+     "fader": "Aux1",
+     "attenuate_mid": false
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Clipper-None-required",
+   "filter": {
+    "type": "Clipper",
+    "parameters": {}
+   }
+  },
+  {
+   "id": "Clipper-None-required-defaults",
+   "filter": {
+    "type": "Clipper",
+    "parameters": {
+     "soft_clip": null
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "Clipper-None-all",
+   "filter": {
+    "type": "Clipper",
+    "parameters": {
+     "clip_limit": -3.0,
+     "soft_clip": false
+    }
+   }
+  },
+  {
+   "id": "Clipper-None-all-defaults",
+   "filter": {
+    "type": "Clipper",
+    "parameters": {
+     "clip_limit": -3.0,
+     "soft_clip": false
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "LookaheadLimiter-None-required",
+   "filter": {
+    "type": "LookaheadLimiter",
+    "parameters": {
+     "attack": 1.0,
+     "attack_unit": "ms",
+     "release": 100.0,
+     "release_unit": "ms"
+    }
+   }
+  },
+  {
+   "id": "LookaheadLimiter-None-required-defaults",
+   "filter": {
+    "type": "LookaheadLimiter",
+    "parameters": {
+     "attack": 1.0,
+     "attack_unit": "ms",
+     "release": 100.0,
+     "release_unit": "ms",
+     "limit": 0.0
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "LookaheadLimiter-None-all",
+   "filter": {
+    "type": "LookaheadLimiter",
+    "parameters": {
+     "limit": -10.0,
+     "attack": 1.0,
+     "attack_unit": "ms",
+     "release": 100.0,
+     "release_unit": "ms"
+    }
+   }
+  },
+  {
+   "id": "LookaheadLimiter-None-all-defaults",
+   "filter": {
+    "type": "LookaheadLimiter",
+    "parameters": {
+     "limit": -10.0,
+     "attack": 1.0,
+     "attack_unit": "ms",
+     "release": 100.0,
+     "release_unit": "ms"
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "DiffEq-None-required",
+   "filter": {
+    "type": "DiffEq",
+    "parameters": {}
+   }
+  },
+  {
+   "id": "DiffEq-None-required-defaults",
+   "filter": {
+    "type": "DiffEq",
+    "parameters": {
+     "a": null,
+     "b": null
+    },
+    "description": null
+   }
+  },
+  {
+   "id": "DiffEq-None-all",
+   "filter": {
+    "type": "DiffEq",
+    "parameters": {
+     "a": [
+      1.0,
+      -0.1
+     ],
+     "b": [
+      1.0,
+      0.2
+     ]
+    }
+   }
+  },
+  {
+   "id": "DiffEq-None-all-defaults",
+   "filter": {
+    "type": "DiffEq",
+    "parameters": {
+     "a": [
+      1.0,
+      -0.1
+     ],
+     "b": [
+      1.0,
+      0.2
+     ]
+    },
+    "description": null
+   }
+  }
+ ]
+}

--- a/src/camilladsp/eval/groupdelay.ts
+++ b/src/camilladsp/eval/groupdelay.ts
@@ -1,0 +1,97 @@
+/**
+ * Group delay, computed from the coefficients rather than read off the phase.
+ *
+ * Differentiating `H(w) = sum h[k] exp(-jwk)` gives `dH/dw = -j*G(w)`, where
+ * `G` is the transform of the same coefficients weighted by their own index,
+ * `k*h[k]`. Since the group delay is `-d(arg H)/dw = -Im(H'/H)`, that is
+ *
+ *     tau(w) = Re( G(w) / H(w) )
+ *
+ * in samples. There is no phase in it. Every frequency stands alone, so unlike
+ * a delay recovered by differentiating a sampled phase curve, nothing has to be
+ * unwrapped, no whole turns have to be guessed at, and one bad point cannot
+ * move its neighbours. It is also what `scipy.signal.group_delay` computes, so
+ * the results are checkable point by point against SciPy.
+ *
+ * The formula is at its best exactly where reading the phase is at its worst.
+ * Take a symmetric FIR, `H = exp(-jwM)*A(w)` with `A` real and `M` the centre
+ * tap. Then `G/H` works out to `M + j*A'/A`: the singularity at a stopband null
+ * is entirely in the imaginary part, and the real part is exactly `M` at every
+ * frequency, nulls included. The old approach predicted each phase step from
+ * the one below it, which meant walking the prediction through that same
+ * stopband hash and carrying whole turn errors up into the passband.
+ *
+ * Nothing here knows about filter types. A biquad is a ratio of two three tap
+ * polynomials, a DiffEq is a ratio of two longer ones, and a Conv is a single
+ * long one, handled in `conv.ts` with the FFT it already computes.
+ */
+
+/**
+ * The group delay of a polynomial in z^-1, in samples.
+ *
+ * `NaN` at a frequency where the polynomial has vanished into its own rounding
+ * error, which happens only for a zero sitting on the unit circle, sampled
+ * within a hair of dead centre: a Notch at 1000 Hz, evaluated at exactly
+ * 1000 Hz. The answer there is `0/0`. In exact arithmetic it is a perfectly
+ * ordinary number, since a symmetric numerator like that one contributes its
+ * centre tap whatever its magnitude does, but in floating point both parts are
+ * noise and the quotient is worth nothing, so it is a gap in the line rather
+ * than a spike that takes the axis with it. One point either side of the zero
+ * is unaffected: at the plot's own spacing the ratio is good to a part in 1e13.
+ */
+export function polynomialGroupDelay(coeffs: ArrayLike<number>, fs: number, freq: ArrayLike<number>): Float64Array {
+  const out = new Float64Array(freq.length)
+  // the largest the polynomial could be anywhere, so the smallest value that
+  // can still be told apart from the error in adding the terms up
+  let scale = 0.0
+  for (let k = 0; k < coeffs.length; k++) scale += Math.abs(coeffs[k])
+  const floor = scale * coeffs.length * Number.EPSILON
+  for (let n = 0; n < freq.length; n++) {
+    const w = (2.0 * Math.PI * freq[n]) / fs
+    let pre = 0.0
+    let pim = 0.0
+    let gre = 0.0
+    let gim = 0.0
+    for (let k = 0; k < coeffs.length; k++) {
+      const cos = Math.cos(k * w)
+      const sin = Math.sin(k * w)
+      pre += coeffs[k] * cos
+      pim -= coeffs[k] * sin
+      gre += k * coeffs[k] * cos
+      gim -= k * coeffs[k] * sin
+    }
+    const denom = pre * pre + pim * pim
+    out[n] = denom <= floor * floor ? NaN : (gre * pre + gim * pim) / denom
+  }
+  return out
+}
+
+/**
+ * The group delay of `B(z)/A(z)` in samples, for any filter written as a ratio
+ * of polynomials in z^-1.
+ *
+ * `arg H = arg B - arg A`, so the delays subtract.
+ */
+export function rationalGroupDelay(
+  b: ArrayLike<number>,
+  a: ArrayLike<number>,
+  fs: number,
+  freq: ArrayLike<number>,
+): Float64Array {
+  const numerator = polynomialGroupDelay(b, fs, freq)
+  const denominator = polynomialGroupDelay(a, fs, freq)
+  for (let n = 0; n < numerator.length; n++) numerator[n] -= denominator[n]
+  return numerator
+}
+
+/** Add `delay` into `total`, elementwise. Group delay is additive along a cascade. */
+export function addDelayInto(total: Float64Array, delay: ArrayLike<number>): void {
+  for (let n = 0; n < total.length; n++) total[n] += delay[n]
+}
+
+/** Samples to milliseconds, the unit the plots draw. */
+export function delayInMs(samples: ArrayLike<number>, fs: number): number[] {
+  const out = new Array<number>(samples.length)
+  for (let n = 0; n < out.length; n++) out[n] = (samples[n] / fs) * 1000.0
+  return out
+}

--- a/src/camilladsp/eval/index.ts
+++ b/src/camilladsp/eval/index.ts
@@ -6,7 +6,7 @@
  * browser, which is almost always the faster machine of the two, and needs no
  * network at all except for Conv filters that read coefficients from a file.
  */
-import { magnitudeDb, multiplyInto, phaseDegrees, unitCurve } from "./complex"
+import { blankNoisyPhase, magnitudeDb, multiplyInto, phaseDegrees, unitCurve } from "./complex"
 import { convComplexGain } from "./conv"
 import { complexGain } from "./filters"
 import { FilterEvalError, num, numList, Params } from "./params"
@@ -23,7 +23,7 @@ const NPOINTS = 1000
  *
  * The step is the span divided by the number of points rather than by one
  * less, so the last point falls just short of `maxval`. That is what the DSP's
- * own plots do, and the golden fixture pins it.
+ * own plots do, and `eval.test.ts` pins it.
  */
 export function logspace(minval: number, maxval: number, npoints: number): Float64Array {
   const logmin = Math.log10(minval)
@@ -57,7 +57,7 @@ interface ConvCoefficients {
  * Dragging a control anywhere in a pipeline step re-evaluates every filter in
  * it, so without this a neighbouring Conv would be refetched on every frame.
  * The entries are large, up to a few megabytes for a long impulse response, so
- * only the most recent few are kept.
+ * only the least recently used few are kept.
  */
 const COEFF_CACHE_SIZE = 8
 const coeffCache = new Map<string, Promise<ConvCoefficients>>()
@@ -66,7 +66,13 @@ function cacheKey(filterconf: Filter, samplerate: number, channels: number): str
   return JSON.stringify([filterconf.parameters, samplerate, channels])
 }
 
-/** Drop the cached coefficients. Exported for tests. */
+/**
+ * Drop the cached coefficients.
+ *
+ * The cache is keyed on the filter parameters, so it cannot see a coefficient
+ * file being replaced under a name it already holds. Call this whenever the
+ * files on the backend change: after an upload, a delete or a rename.
+ */
 export function clearCoefficientCache(): void {
   coeffCache.clear()
 }
@@ -83,7 +89,13 @@ async function fetchConvCoefficients(
 ): Promise<ConvCoefficients> {
   const key = cacheKey(filterconf, samplerate, channels)
   const cached = coeffCache.get(key)
-  if (cached !== undefined) return cached
+  if (cached !== undefined) {
+    // re-insert, so the entries fall out of the Map in least recently used
+    // order rather than in the order they were first fetched
+    coeffCache.delete(key)
+    coeffCache.set(key, cached)
+    return cached
+  }
 
   const pending = (async () => {
     const response = await fetch("/api/convcoeffs", {
@@ -159,6 +171,8 @@ export async function evalFilter(filterconf: Filter, options: EvalOptions): Prom
 
   const magnitude = magnitudeDb(curve)
   const phase = phaseDegrees(curve)
+  // only an FIR has a stopband full of nulls for the plot grid to alias
+  if (filterconf.type === "Conv") blankNoisyPhase(magnitude, phase)
   const groupdelay = calcGroupDelay(result.f, phase)
   result.magnitude = magnitude
   result.phase = phase
@@ -206,10 +220,12 @@ export async function evalFilterStep(config: Config, stepIndex: number, options:
 
   const total = unitCurve(npoints)
   const convOptions: FilterOption[][] = []
+  let hasConv = false
   for (const filterName of names) {
     const filterconf = config.filters?.[filterName]
     if (filterconf === undefined) throw new FilterEvalError(`Unknown filter ${filterName}`)
     if (filterconf.type === "Conv") {
+      hasConv = true
       const conv = await convCoefficients(filterconf, samplerate, channels)
       // the bulk delay of a Conv is part of the step's response, so unlike the
       // single filter plot it is not removed here
@@ -223,6 +239,7 @@ export async function evalFilterStep(config: Config, stepIndex: number, options:
 
   const magnitude = magnitudeDb(total)
   const phase = phaseDegrees(total)
+  if (hasConv) blankNoisyPhase(magnitude, phase)
   const groupdelay = calcGroupDelay(freq, phase)
   return {
     name,

--- a/src/camilladsp/eval/index.ts
+++ b/src/camilladsp/eval/index.ts
@@ -48,7 +48,8 @@ export interface EvalOptions {
 /** What the backend knows about a Conv filter's coefficient file. */
 interface ConvCoefficients {
   options: FilterOption[]
-  coefficients: number[]
+  // whichever width the backend judged lossless for the source file
+  coefficients: Float32Array | Float64Array
 }
 
 /**
@@ -56,11 +57,48 @@ interface ConvCoefficients {
  *
  * Dragging a control anywhere in a pipeline step re-evaluates every filter in
  * it, so without this a neighbouring Conv would be refetched on every frame.
- * The entries are large, up to a few megabytes for a long impulse response, so
- * only the least recently used few are kept.
+ *
+ * Bounded by how much memory the entries take rather than by how many there
+ * are, because their sizes differ by orders of magnitude: a Values filter is a
+ * handful of bytes and a room correction is megabytes. Counting entries would
+ * be both too loose, eight long impulse responses being hundreds of megabytes,
+ * and too tight, a pipeline step with a dozen short ones evicting itself on
+ * every pass.
  */
-const COEFF_CACHE_SIZE = 8
-const coeffCache = new Map<string, Promise<ConvCoefficients>>()
+const COEFF_CACHE_BYTES = 64 * 1024 * 1024
+
+interface CacheEntry {
+  coefficients: Promise<ConvCoefficients>
+  /** Filled in when the fetch resolves, since the size is unknown until then. */
+  bytes: number
+}
+
+const coeffCache = new Map<string, CacheEntry>()
+
+/**
+ * How many of the oldest entries have to go for the rest to fit in the budget,
+ * given their sizes in least recently used order.
+ *
+ * The newest is never one of them. It is the response to whatever is being
+ * plotted right now, so dropping it would mean fetching it again immediately,
+ * and a single file larger than the whole budget would never be cached at all.
+ */
+export function entriesToEvict(sizes: number[], budget: number): number {
+  let total = sizes.reduce((sum, bytes) => sum + bytes, 0)
+  let evicted = 0
+  while (total > budget && evicted < sizes.length - 1) {
+    total -= sizes[evicted]
+    evicted++
+  }
+  return evicted
+}
+
+function pruneCoefficientCache(): void {
+  const sizes = [...coeffCache.values()].map((entry) => entry.bytes)
+  const evicted = entriesToEvict(sizes, COEFF_CACHE_BYTES)
+  const keys = [...coeffCache.keys()]
+  for (let n = 0; n < evicted; n++) coeffCache.delete(keys[n])
+}
 
 function cacheKey(filterconf: Filter, samplerate: number, channels: number): string {
   return JSON.stringify([filterconf.parameters, samplerate, channels])
@@ -75,6 +113,32 @@ function cacheKey(filterconf: Filter, samplerate: number, channels: number): str
  */
 export function clearCoefficientCache(): void {
   coeffCache.clear()
+}
+
+/**
+ * Unpack the reply from `/api/convcoeffs`.
+ *
+ * Not JSON. A million taps as decimal text is 21.8 MB, 390 ms for the backend
+ * to format and 37 ms here to parse; as raw floats it is 8.4 MB or less, 19 ms
+ * to write, and free to read, because the array below is a view over the bytes
+ * rather than a copy of them. The backend is often the slowest machine in the
+ * system, so that is where it matters most.
+ *
+ * The frame is a little endian uint32 length, a JSON header of that length,
+ * padding to the next multiple of 8, and then the samples. The padding is what
+ * makes the view possible, since Float64Array needs a byte offset it can divide
+ * by 8. The header carries the samplerate and channel options, and the width of
+ * the samples: the backend sends float32 when the source file holds no more
+ * than that, which is every format except F64_LE, S32_LE and TEXT, so the usual
+ * coefficient file crosses the wire at half the size and loses nothing.
+ */
+function unframeCoefficients(buffer: ArrayBuffer): ConvCoefficients {
+  const headerLength = new DataView(buffer).getUint32(0, true)
+  const header = new TextDecoder().decode(new Uint8Array(buffer, 4, headerLength))
+  const { options, format } = JSON.parse(header) as { options: FilterOption[]; format: string }
+  const start = 4 + headerLength + ((8 - ((4 + headerLength) % 8)) % 8)
+  const coefficients = format === "float32" ? new Float32Array(buffer, start) : new Float64Array(buffer, start)
+  return { options, coefficients }
 }
 
 /**
@@ -94,7 +158,7 @@ async function fetchConvCoefficients(
     // order rather than in the order they were first fetched
     coeffCache.delete(key)
     coeffCache.set(key, cached)
-    return cached
+    return cached.coefficients
   }
 
   const pending = (async () => {
@@ -104,17 +168,19 @@ async function fetchConvCoefficients(
       body: JSON.stringify({ config: filterconf, samplerate, channels }),
     })
     if (!response.ok) throw new FilterEvalError(await response.text())
-    return (await response.json()) as ConvCoefficients
+    return unframeCoefficients(await response.arrayBuffer())
   })()
-  // a failed fetch must not be remembered, or the filter can never plot again
-  pending.catch(() => coeffCache.delete(key))
+  const entry: CacheEntry = { coefficients: pending, bytes: 0 }
+  pending.then(
+    (resolved) => {
+      entry.bytes = resolved.coefficients.byteLength
+      pruneCoefficientCache()
+    },
+    // a failed fetch must not be remembered, or the filter can never plot again
+    () => coeffCache.delete(key),
+  )
 
-  coeffCache.set(key, pending)
-  while (coeffCache.size > COEFF_CACHE_SIZE) {
-    const oldest = coeffCache.keys().next()
-    if (oldest.done) break
-    coeffCache.delete(oldest.value)
-  }
+  coeffCache.set(key, entry)
   return pending
 }
 
@@ -128,14 +194,14 @@ async function convCoefficients(filterconf: Filter, samplerate: number, channels
   const subtype = params.type
   if (subtype === "Raw" || subtype === "Wav") return fetchConvCoefficients(filterconf, samplerate, channels)
   if (subtype === "Dummy") {
-    const coefficients = new Array<number>(num(params, "length")).fill(0.0)
+    const coefficients = new Float64Array(num(params, "length"))
     coefficients[0] = 1.0
     return { options: [], coefficients }
   }
-  if (subtype === "Values") return { options: [], coefficients: numList(params, "values") }
+  if (subtype === "Values") return { options: [], coefficients: Float64Array.from(numList(params, "values")) }
   // a Conv with no parameters at all is a single unity coefficient, which is
   // what CamillaDSP falls back to
-  if (subtype === undefined) return { options: [], coefficients: [1.0] }
+  if (subtype === undefined) return { options: [], coefficients: Float64Array.from([1.0]) }
   throw new FilterEvalError(`Unknown Conv subtype ${String(subtype)}`)
 }
 
@@ -164,7 +230,7 @@ export async function evalFilter(filterconf: Filter, options: EvalOptions): Prom
     curve = convComplexGain(conv.coefficients, samplerate, freq, true)
     result.options = conv.options
     result.impulse = conv.coefficients
-    result.time = conv.coefficients.map((_, n) => n / samplerate)
+    result.time = Float64Array.from(conv.coefficients, (_, n) => n / samplerate)
   } else {
     curve = complexGain(filterconf, samplerate, volume, freq)
   }

--- a/src/camilladsp/eval/index.ts
+++ b/src/camilladsp/eval/index.ts
@@ -7,10 +7,10 @@
  * network at all except for Conv filters that read coefficients from a file.
  */
 import { blankPhaseBelow, magnitudeDb, multiplyInto, phaseDegrees, phaseNoiseFloor, unitCurve } from "./complex"
-import { convComplexGain } from "./conv"
-import { complexGain } from "./filters"
+import { convComplexGain, convGroupDelay } from "./conv"
+import { complexGain, groupDelaySamples } from "./filters"
+import { addDelayInto, delayInMs } from "./groupdelay"
 import { FilterEvalError, num, numList, Params } from "./params"
-import { calcGroupDelay } from "./unwrap"
 import { ChartContent, FilterOption } from "../../utilities/chart"
 import { Config, Filter } from "../config"
 
@@ -206,17 +206,17 @@ async function convCoefficients(filterconf: Filter, samplerate: number, channels
 }
 
 /**
- * The phase the group delay is read from: the unreadable stretch taken out.
+ * Hide the group delay where the phase is hidden.
  *
- * This is not the toggle the plot offers. The group delay predicts each step
- * from the one below it in frequency, so letting it run through a region of
- * aliased phase moves the readable part of the curve as well, by hundreds of
- * milliseconds on a highpass. The phase trace itself has no such coupling, so
- * that one is the reader's to show or hide.
+ * Purely so the two curves agree about where a convolution filter stops being
+ * readable. Nothing depends on it any more: the delay is computed from the
+ * coefficients, point by point, so a value in the aliased region is wrong only
+ * about itself and cannot move the passband. Before that it was load bearing,
+ * and an unblanked stretch moved the readable delay of a highpass by 608 ms.
  */
-function blankedForGroupDelay(phase: number[], magnitude: number[], floor: number | undefined): number[] {
-  if (floor === undefined) return phase
-  const blanked = [...phase]
+function blankedBelowFloor(delay: number[], magnitude: number[], floor: number | undefined): number[] {
+  if (floor === undefined) return delay
+  const blanked = [...delay]
   blankPhaseBelow(floor, magnitude, blanked)
   return blanked
 }
@@ -239,28 +239,31 @@ export async function evalFilter(filterconf: Filter, options: EvalOptions): Prom
   }
 
   let curve
+  let delaySamples
   if (filterconf.type === "Conv") {
     const conv = await convCoefficients(filterconf, samplerate, channels)
     // Convolution is the one type with an impulse response to show, and its
     // bulk delay is removed so the phase plot stays readable.
     curve = convComplexGain(conv.coefficients, samplerate, freq, true)
+    delaySamples = convGroupDelay(conv.coefficients, samplerate, freq, true)
     result.options = conv.options
     result.impulse = conv.coefficients
     result.time = Float64Array.from(conv.coefficients, (_, n) => n / samplerate)
   } else {
     curve = complexGain(filterconf, samplerate, volume, freq)
+    delaySamples = groupDelaySamples(filterconf, samplerate, volume, freq)
   }
 
   const magnitude = magnitudeDb(curve)
   const phase = phaseDegrees(curve)
   // only an FIR has a stopband full of nulls for the plot grid to alias
   const phaseFloor = filterconf.type === "Conv" ? phaseNoiseFloor(magnitude) : undefined
-  const groupdelay = calcGroupDelay(result.f, blankedForGroupDelay(phase, magnitude, phaseFloor))
   result.phaseFloor = phaseFloor
   result.magnitude = magnitude
   result.phase = phase
-  result.f_groupdelay = groupdelay.freq
-  result.groupdelay = groupdelay.groupdelay
+  // one value per plot frequency, not per midpoint between two of them
+  result.f_groupdelay = result.f
+  result.groupdelay = blankedBelowFloor(delayInMs(delaySamples, samplerate), magnitude, phaseFloor)
   return result
 }
 
@@ -302,6 +305,10 @@ export async function evalFilterStep(config: Config, stepIndex: number, options:
   const names = step !== undefined && step.type === "Filter" ? step.names : []
 
   const total = unitCurve(npoints)
+  // filters multiply, delays add: the group delay of a cascade is the sum of
+  // the group delays of its parts, so nothing has to be recovered from the
+  // phase of the product
+  const totalDelay = new Float64Array(npoints)
   const convOptions: FilterOption[][] = []
   let hasConv = false
   for (const filterName of names) {
@@ -313,17 +320,19 @@ export async function evalFilterStep(config: Config, stepIndex: number, options:
       // the bulk delay of a Conv is part of the step's response, so unlike the
       // single filter plot it is not removed here
       multiplyInto(total, convComplexGain(conv.coefficients, samplerate, freq))
+      addDelayInto(totalDelay, convGroupDelay(conv.coefficients, samplerate, freq))
       const subtype = (filterconf.parameters ?? {}).type
       if (subtype === "Raw" || subtype === "Wav") convOptions.push(conv.options)
     } else {
       multiplyInto(total, complexGain(filterconf, samplerate, volume, freq))
+      addDelayInto(totalDelay, groupDelaySamples(filterconf, samplerate, volume, freq))
     }
   }
 
   const magnitude = magnitudeDb(total)
   const phase = phaseDegrees(total)
   const phaseFloor = hasConv ? phaseNoiseFloor(magnitude) : undefined
-  const groupdelay = calcGroupDelay(freq, blankedForGroupDelay(phase, magnitude, phaseFloor))
+  const groupdelay = blankedBelowFloor(delayInMs(totalDelay, samplerate), magnitude, phaseFloor)
   return {
     name,
     samplerate,
@@ -334,7 +343,7 @@ export async function evalFilterStep(config: Config, stepIndex: number, options:
     magnitude,
     phase,
     phaseFloor,
-    f_groupdelay: groupdelay.freq,
-    groupdelay: groupdelay.groupdelay,
+    f_groupdelay: Array.from(freq),
+    groupdelay,
   }
 }

--- a/src/camilladsp/eval/index.ts
+++ b/src/camilladsp/eval/index.ts
@@ -1,0 +1,239 @@
+/**
+ * Filter evaluation for the plots.
+ *
+ * This used to be a round trip to the backend, which evaluated the transfer
+ * function in numpy and returned five 1000 point curves. It now runs in the
+ * browser, which is almost always the faster machine of the two, and needs no
+ * network at all except for Conv filters that read coefficients from a file.
+ */
+import { magnitudeDb, multiplyInto, phaseDegrees, unitCurve } from "./complex"
+import { convComplexGain } from "./conv"
+import { complexGain } from "./filters"
+import { FilterEvalError, num, numList, Params } from "./params"
+import { calcGroupDelay } from "./unwrap"
+import { ChartContent, FilterOption } from "../../utilities/chart"
+import { Config, Filter } from "../config"
+
+export { FilterEvalError } from "./params"
+
+const NPOINTS = 1000
+
+/**
+ * A log spaced frequency vector.
+ *
+ * The step is the span divided by the number of points rather than by one
+ * less, so the last point falls just short of `maxval`. That is what the DSP's
+ * own plots do, and the golden fixture pins it.
+ */
+export function logspace(minval: number, maxval: number, npoints: number): Float64Array {
+  const logmin = Math.log10(minval)
+  const logmax = Math.log10(maxval)
+  const perstep = (logmax - logmin) / npoints
+  const values = new Float64Array(npoints)
+  for (let n = 0; n < npoints; n++) values[n] = Math.pow(10.0, logmin + n * perstep)
+  return values
+}
+
+export interface EvalOptions {
+  /** Plot title. */
+  name?: string
+  samplerate: number
+  /** Capture channel count, used to resolve $channels$ in coefficient paths. */
+  channels: number
+  /** Volume to evaluate a Loudness filter at. */
+  volume?: number
+  npoints?: number
+}
+
+/** What the backend knows about a Conv filter's coefficient file. */
+interface ConvCoefficients {
+  options: FilterOption[]
+  coefficients: number[]
+}
+
+/**
+ * Coefficients keyed on the request that produced them.
+ *
+ * Dragging a control anywhere in a pipeline step re-evaluates every filter in
+ * it, so without this a neighbouring Conv would be refetched on every frame.
+ * The entries are large, up to a few megabytes for a long impulse response, so
+ * only the most recent few are kept.
+ */
+const COEFF_CACHE_SIZE = 8
+const coeffCache = new Map<string, Promise<ConvCoefficients>>()
+
+function cacheKey(filterconf: Filter, samplerate: number, channels: number): string {
+  return JSON.stringify([filterconf.parameters, samplerate, channels])
+}
+
+/** Drop the cached coefficients. Exported for tests. */
+export function clearCoefficientCache(): void {
+  coeffCache.clear()
+}
+
+/**
+ * Read the coefficients of a file backed Conv filter from the backend. The
+ * backend resolves the path, applies the $samplerate$ and $channels$ tokens
+ * and decodes the samples; it does no DSP.
+ */
+async function fetchConvCoefficients(
+  filterconf: Filter,
+  samplerate: number,
+  channels: number,
+): Promise<ConvCoefficients> {
+  const key = cacheKey(filterconf, samplerate, channels)
+  const cached = coeffCache.get(key)
+  if (cached !== undefined) return cached
+
+  const pending = (async () => {
+    const response = await fetch("/api/convcoeffs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ config: filterconf, samplerate, channels }),
+    })
+    if (!response.ok) throw new FilterEvalError(await response.text())
+    return (await response.json()) as ConvCoefficients
+  })()
+  // a failed fetch must not be remembered, or the filter can never plot again
+  pending.catch(() => coeffCache.delete(key))
+
+  coeffCache.set(key, pending)
+  while (coeffCache.size > COEFF_CACHE_SIZE) {
+    const oldest = coeffCache.keys().next()
+    if (oldest.done) break
+    coeffCache.delete(oldest.value)
+  }
+  return pending
+}
+
+/**
+ * The impulse response of a Conv filter, and the coefficient file options that
+ * came with it. Only Raw and Wav reach the backend; Dummy and Values are built
+ * here.
+ */
+async function convCoefficients(filterconf: Filter, samplerate: number, channels: number): Promise<ConvCoefficients> {
+  const params = (filterconf.parameters ?? {}) as Params
+  const subtype = params.type
+  if (subtype === "Raw" || subtype === "Wav") return fetchConvCoefficients(filterconf, samplerate, channels)
+  if (subtype === "Dummy") {
+    const coefficients = new Array<number>(num(params, "length")).fill(0.0)
+    coefficients[0] = 1.0
+    return { options: [], coefficients }
+  }
+  if (subtype === "Values") return { options: [], coefficients: numList(params, "values") }
+  // a Conv with no parameters at all is a single unity coefficient, which is
+  // what CamillaDSP falls back to
+  if (subtype === undefined) return { options: [], coefficients: [1.0] }
+  throw new FilterEvalError(`Unknown Conv subtype ${String(subtype)}`)
+}
+
+/** Evaluate one filter, for the plot in the filters tab. */
+export async function evalFilter(filterconf: Filter, options: EvalOptions): Promise<ChartContent> {
+  const { samplerate, channels } = options
+  const volume = options.volume ?? 0.0
+  const npoints = options.npoints ?? NPOINTS
+  const name = options.name ?? `unnamed ${filterconf.type}`
+  const freq = logspace(1.0, (samplerate * 0.95) / 2.0, npoints)
+
+  const result: ChartContent = {
+    name,
+    samplerate,
+    channels,
+    options: [],
+    f: Array.from(freq),
+    time: [],
+  }
+
+  let curve
+  if (filterconf.type === "Conv") {
+    const conv = await convCoefficients(filterconf, samplerate, channels)
+    // Convolution is the one type with an impulse response to show, and its
+    // bulk delay is removed so the phase plot stays readable.
+    curve = convComplexGain(conv.coefficients, samplerate, freq, true)
+    result.options = conv.options
+    result.impulse = conv.coefficients
+    result.time = conv.coefficients.map((_, n) => n / samplerate)
+  } else {
+    curve = complexGain(filterconf, samplerate, volume, freq)
+  }
+
+  const magnitude = magnitudeDb(curve)
+  const phase = phaseDegrees(curve)
+  const groupdelay = calcGroupDelay(result.f, phase)
+  result.magnitude = magnitude
+  result.phase = phase
+  result.f_groupdelay = groupdelay.freq
+  result.groupdelay = groupdelay.groupdelay
+  return result
+}
+
+/**
+ * The samplerate and channel options of a whole filter step: the ones every
+ * Conv in the step can offer.
+ */
+export function intersectFilterOptions(
+  perFilter: FilterOption[][],
+  defaultSamplerate: number,
+  defaultChannels: number,
+): FilterOption[] {
+  const pairsOf = (options: FilterOption[]) =>
+    new Set(options.map((o) => `${o.samplerate ?? defaultSamplerate}/${o.channels ?? defaultChannels}`))
+  const perFilterPairs = perFilter.map(pairsOf)
+  if (perFilterPairs.length === 0) return []
+  const shared = [...perFilterPairs[0]].filter((pair) => perFilterPairs.every((pairs) => pairs.has(pair)))
+  return shared
+    .map((pair) => {
+      const [samplerate, channels] = pair.split("/").map(Number)
+      return {
+        name: `${samplerate} Hz - ${channels} Channels`,
+        samplerate,
+        channels,
+      }
+    })
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+}
+
+/** Evaluate a whole filter step, for the plot in the pipeline tab. */
+export async function evalFilterStep(config: Config, stepIndex: number, options: EvalOptions): Promise<ChartContent> {
+  const { samplerate, channels } = options
+  const volume = options.volume ?? 0.0
+  const npoints = options.npoints ?? NPOINTS
+  const name = options.name ?? `Filterstep ${stepIndex}`
+  const freq = logspace(10.0, (samplerate * 0.95) / 2.0, npoints)
+
+  const step = config.pipeline?.[stepIndex]
+  const names = step !== undefined && step.type === "Filter" ? step.names : []
+
+  const total = unitCurve(npoints)
+  const convOptions: FilterOption[][] = []
+  for (const filterName of names) {
+    const filterconf = config.filters?.[filterName]
+    if (filterconf === undefined) throw new FilterEvalError(`Unknown filter ${filterName}`)
+    if (filterconf.type === "Conv") {
+      const conv = await convCoefficients(filterconf, samplerate, channels)
+      // the bulk delay of a Conv is part of the step's response, so unlike the
+      // single filter plot it is not removed here
+      multiplyInto(total, convComplexGain(conv.coefficients, samplerate, freq))
+      const subtype = (filterconf.parameters ?? {}).type
+      if (subtype === "Raw" || subtype === "Wav") convOptions.push(conv.options)
+    } else {
+      multiplyInto(total, complexGain(filterconf, samplerate, volume, freq))
+    }
+  }
+
+  const magnitude = magnitudeDb(total)
+  const phase = phaseDegrees(total)
+  const groupdelay = calcGroupDelay(freq, phase)
+  return {
+    name,
+    samplerate,
+    channels,
+    options: intersectFilterOptions(convOptions, samplerate, channels),
+    f: Array.from(freq),
+    time: [],
+    magnitude,
+    phase,
+    f_groupdelay: groupdelay.freq,
+    groupdelay: groupdelay.groupdelay,
+  }
+}

--- a/src/camilladsp/eval/index.ts
+++ b/src/camilladsp/eval/index.ts
@@ -6,7 +6,7 @@
  * browser, which is almost always the faster machine of the two, and needs no
  * network at all except for Conv filters that read coefficients from a file.
  */
-import { blankNoisyPhase, magnitudeDb, multiplyInto, phaseDegrees, unitCurve } from "./complex"
+import { blankPhaseBelow, magnitudeDb, multiplyInto, phaseDegrees, phaseNoiseFloor, unitCurve } from "./complex"
 import { convComplexGain } from "./conv"
 import { complexGain } from "./filters"
 import { FilterEvalError, num, numList, Params } from "./params"
@@ -205,6 +205,22 @@ async function convCoefficients(filterconf: Filter, samplerate: number, channels
   throw new FilterEvalError(`Unknown Conv subtype ${String(subtype)}`)
 }
 
+/**
+ * The phase the group delay is read from: the unreadable stretch taken out.
+ *
+ * This is not the toggle the plot offers. The group delay predicts each step
+ * from the one below it in frequency, so letting it run through a region of
+ * aliased phase moves the readable part of the curve as well, by hundreds of
+ * milliseconds on a highpass. The phase trace itself has no such coupling, so
+ * that one is the reader's to show or hide.
+ */
+function blankedForGroupDelay(phase: number[], magnitude: number[], floor: number | undefined): number[] {
+  if (floor === undefined) return phase
+  const blanked = [...phase]
+  blankPhaseBelow(floor, magnitude, blanked)
+  return blanked
+}
+
 /** Evaluate one filter, for the plot in the filters tab. */
 export async function evalFilter(filterconf: Filter, options: EvalOptions): Promise<ChartContent> {
   const { samplerate, channels } = options
@@ -238,8 +254,9 @@ export async function evalFilter(filterconf: Filter, options: EvalOptions): Prom
   const magnitude = magnitudeDb(curve)
   const phase = phaseDegrees(curve)
   // only an FIR has a stopband full of nulls for the plot grid to alias
-  if (filterconf.type === "Conv") blankNoisyPhase(magnitude, phase)
-  const groupdelay = calcGroupDelay(result.f, phase)
+  const phaseFloor = filterconf.type === "Conv" ? phaseNoiseFloor(magnitude) : undefined
+  const groupdelay = calcGroupDelay(result.f, blankedForGroupDelay(phase, magnitude, phaseFloor))
+  result.phaseFloor = phaseFloor
   result.magnitude = magnitude
   result.phase = phase
   result.f_groupdelay = groupdelay.freq
@@ -305,8 +322,8 @@ export async function evalFilterStep(config: Config, stepIndex: number, options:
 
   const magnitude = magnitudeDb(total)
   const phase = phaseDegrees(total)
-  if (hasConv) blankNoisyPhase(magnitude, phase)
-  const groupdelay = calcGroupDelay(freq, phase)
+  const phaseFloor = hasConv ? phaseNoiseFloor(magnitude) : undefined
+  const groupdelay = calcGroupDelay(freq, blankedForGroupDelay(phase, magnitude, phaseFloor))
   return {
     name,
     samplerate,
@@ -316,6 +333,7 @@ export async function evalFilterStep(config: Config, stepIndex: number, options:
     time: [],
     magnitude,
     phase,
+    phaseFloor,
     f_groupdelay: groupdelay.freq,
     groupdelay: groupdelay.groupdelay,
   }

--- a/src/camilladsp/eval/params.ts
+++ b/src/camilladsp/eval/params.ts
@@ -1,0 +1,81 @@
+/**
+ * Narrowing helpers for filter parameters.
+ *
+ * `Filter.parameters` is an untyped bag of `FilterParameterValue`, so the
+ * evaluator has to narrow every value it reads. A missing key and an explicit
+ * null both mean "not set": the schemas declare optional parameters as
+ * `default: null`, so a config that has been through the validator carries
+ * nulls where the user left a parameter out.
+ */
+import { FilterParameterValue, PeqBand } from "../config"
+
+export type Params = { [name: string]: FilterParameterValue }
+
+export class FilterEvalError extends Error {}
+
+function present(params: Params, key: string): boolean {
+  const value = params[key]
+  return value !== undefined && value !== null
+}
+
+/** A required number. */
+export function num(params: Params, key: string): number {
+  const value = params[key]
+  if (typeof value !== "number") throw new FilterEvalError(`Missing or invalid parameter '${key}'`)
+  return value
+}
+
+/** An optional number, `undefined` when not set. */
+export function optNum(params: Params, key: string): number | undefined {
+  if (!present(params, key)) return undefined
+  return num(params, key)
+}
+
+/** An optional number, falling back to the DSP default when not set. */
+export function numOr(params: Params, key: string, fallback: number): number {
+  return optNum(params, key) ?? fallback
+}
+
+/**
+ * An optional number where zero is not a usable value either, so it falls back
+ * to the default as well. GraphicEqualizer's frequency limits work this way:
+ * the DSP rejects zero, and it must not reach log2.
+ */
+export function positiveNumOr(params: Params, key: string, fallback: number): number {
+  const value = optNum(params, key)
+  return value ? value : fallback
+}
+
+/** An optional boolean. Anything not explicitly true counts as false. */
+export function flag(params: Params, key: string): boolean {
+  return params[key] === true
+}
+
+export function optStr(params: Params, key: string): string | undefined {
+  if (!present(params, key)) return undefined
+  const value = params[key]
+  if (typeof value !== "string") throw new FilterEvalError(`Invalid parameter '${key}'`)
+  return value
+}
+
+/** A list of numbers. An absent or empty list falls back to the given default. */
+export function numListOr(params: Params, key: string, fallback: number[]): number[] {
+  const value = params[key]
+  if (!Array.isArray(value) || value.length === 0) return fallback
+  if (value.some((entry) => typeof entry !== "number"))
+    throw new FilterEvalError(`Invalid parameter '${key}', expected a list of numbers`)
+  return value as number[]
+}
+
+export function numList(params: Params, key: string): number[] {
+  const value = params[key]
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "number"))
+    throw new FilterEvalError(`Missing or invalid parameter '${key}', expected a list of numbers`)
+  return value as number[]
+}
+
+export function peqBands(params: Params, key: string): PeqBand[] {
+  const value = params[key]
+  if (!Array.isArray(value)) throw new FilterEvalError(`Missing or invalid parameter '${key}'`)
+  return value as PeqBand[]
+}

--- a/src/camilladsp/eval/properties.test.ts
+++ b/src/camilladsp/eval/properties.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Closed-form properties every filter must satisfy.
+ *
+ * These are the tests that trust neither implementation. Each one asserts
+ * something that follows from what the filter *is* — a Butterworth is 3 dB
+ * down at its cutoff whatever its order, an allpass passes every frequency at
+ * unity, a delay of N samples has a group delay of N/fs — so they catch a
+ * wrong coefficient without reference to any other code, and a genuine fix
+ * makes them go green rather than red.
+ *
+ * The evaluator that was ported into this directory was never covered by
+ * anything like this. It shipped with a Delay that read the pre-5.0 `unit`
+ * key, so every non-millisecond delay was plotted as milliseconds; the group
+ * delay test below fails outright on that bug.
+ */
+import { describe, expect, it } from "vitest"
+import { Filter } from "../config"
+import { magnitudeDb, phaseDegrees } from "./complex"
+import { complexGain } from "./filters"
+import { calcGroupDelay } from "./unwrap"
+
+const FS = 48000
+
+/** A wide log grid, deliberately not the one the plots use. */
+const SWEEP = Array.from({ length: 400 }, (_, n) => 10.0 * Math.pow(10.0 ** (1 / 133), n))
+
+function filter(type: string, parameters: Filter["parameters"]): Filter {
+  return { type, description: null, parameters }
+}
+
+function gainAt(f: Filter, freqs: number[]): number[] {
+  return magnitudeDb(complexGain(f, FS, 0.0, Float64Array.from(freqs)))
+}
+
+/** Group delay in ms across the sweep, from the same path the plots use. */
+function groupDelay(f: Filter, freqs: number[]): number[] {
+  const curve = complexGain(f, FS, 0.0, Float64Array.from(freqs))
+  return calcGroupDelay(freqs, phaseDegrees(curve)).groupdelay
+}
+
+const HALF_POWER_DB = 20 * Math.log10(1 / Math.SQRT2)
+
+describe("a notch is a true zero at its centre frequency", () => {
+  it.each([500.0, 1000.0, 7000.0])("Notch at %d Hz", (freq) => {
+    // The zero sits exactly on the unit circle, so the response there is not
+    // merely small, it is zero to within the floor the plot adds.
+    expect(gainAt(filter("Biquad", { type: "Notch", freq, q: 2.0 }), [freq])[0]).toBeLessThan(-200.0)
+  })
+
+  it("leaves everything well away from the notch alone", () => {
+    const gains = gainAt(filter("Biquad", { type: "Notch", freq: 1000.0, q: 8.0 }), [20.0, 100.0, 10000.0, 20000.0])
+    gains.forEach((gain) => expect(gain).toBeCloseTo(0.0, 2))
+  })
+
+  it("a bandpass is exactly unity at its centre frequency", () => {
+    // The constant peak gain form, so the peak is 0 dB whatever the Q.
+    for (const q of [0.5, 2.0, 8.0]) {
+      expect(gainAt(filter("Biquad", { type: "Bandpass", freq: 1000.0, q }), [1000.0])[0]).toBeCloseTo(0.0, 9)
+    }
+  })
+})
+
+describe("an allpass passes every frequency at unity gain", () => {
+  it.each(["Allpass", "AllpassFO"])("%s", (type) => {
+    const params: Filter["parameters"] = { type, freq: 1200.0 }
+    if (type === "Allpass") params.q = 1.5
+    gainAt(filter("Biquad", params), SWEEP).forEach((gain) => expect(gain).toBeCloseTo(0.0, 9))
+  })
+})
+
+describe("a peaking filter hits its gain exactly at the centre", () => {
+  it.each([-12.0, -3.0, 3.0, 12.0])("gain %d dB", (gain) => {
+    const freq = 1000.0
+    expect(gainAt(filter("Biquad", { type: "Peaking", freq, q: 2.0, gain }), [freq])[0]).toBeCloseTo(gain, 9)
+  })
+})
+
+describe("shelving filters reach exactly their gain at DC and Nyquist", () => {
+  // Evaluated at the two points where the transfer function is real, so these
+  // are exact rather than asymptotic.
+  const DC = 0.0
+  const NYQUIST = FS / 2
+
+  it.each([-9.0, 4.5])("Lowshelf, gain %d dB", (gain) => {
+    const f = filter("Biquad", { type: "Lowshelf", freq: 500.0, q: 0.707, gain })
+    expect(gainAt(f, [DC])[0]).toBeCloseTo(gain, 9)
+    expect(gainAt(f, [NYQUIST])[0]).toBeCloseTo(0.0, 9)
+  })
+
+  it.each([-9.0, 4.5])("Highshelf, gain %d dB", (gain) => {
+    const f = filter("Biquad", { type: "Highshelf", freq: 500.0, q: 0.707, gain })
+    expect(gainAt(f, [DC])[0]).toBeCloseTo(0.0, 9)
+    expect(gainAt(f, [NYQUIST])[0]).toBeCloseTo(gain, 9)
+  })
+
+  it.each([-9.0, 4.5])("LowshelfFO, gain %d dB", (gain) => {
+    const f = filter("Biquad", { type: "LowshelfFO", freq: 500.0, gain })
+    expect(gainAt(f, [DC])[0]).toBeCloseTo(gain, 9)
+    expect(gainAt(f, [NYQUIST])[0]).toBeCloseTo(0.0, 9)
+  })
+
+  it.each([-9.0, 4.5])("HighshelfFO, gain %d dB", (gain) => {
+    const f = filter("Biquad", { type: "HighshelfFO", freq: 500.0, gain })
+    expect(gainAt(f, [DC])[0]).toBeCloseTo(0.0, 9)
+    expect(gainAt(f, [NYQUIST])[0]).toBeCloseTo(gain, 9)
+  })
+})
+
+describe("lowpasses and highpasses pass and stop the right ends", () => {
+  it("a first order lowpass is 3 dB down at its cutoff", () => {
+    expect(gainAt(filter("Biquad", { type: "LowpassFO", freq: 1000.0 }), [1000.0])[0]).toBeCloseTo(HALF_POWER_DB, 6)
+  })
+
+  it("a first order highpass is 3 dB down at its cutoff", () => {
+    expect(gainAt(filter("Biquad", { type: "HighpassFO", freq: 1000.0 }), [1000.0])[0]).toBeCloseTo(HALF_POWER_DB, 6)
+  })
+
+  it("a second order lowpass is Q at its cutoff", () => {
+    // The magnitude of an RBJ lowpass at its own corner frequency is exactly Q.
+    for (const q of [0.5, 0.707, 2.0]) {
+      expect(gainAt(filter("Biquad", { type: "Lowpass", freq: 1000.0, q }), [1000.0])[0]).toBeCloseTo(
+        20 * Math.log10(q),
+        6,
+      )
+    }
+  })
+})
+
+describe("Butterworth and Linkwitz-Riley crossovers", () => {
+  // A Butterworth is 3 dB down at its cutoff for every order, and a
+  // Linkwitz-Riley, being two of them in series, is 6 dB down.
+  it.each([2, 3, 4, 5, 6, 7, 8])("a Butterworth of order %d is 3 dB down at its cutoff", (order) => {
+    for (const type of ["ButterworthLowpass", "ButterworthHighpass"]) {
+      expect(gainAt(filter("BiquadCombo", { type, order, freq: 1000.0 }), [1000.0])[0]).toBeCloseTo(HALF_POWER_DB, 6)
+    }
+  })
+
+  it.each([2, 4, 6, 8])("a Linkwitz-Riley of order %d is 6 dB down at its crossover", (order) => {
+    for (const type of ["LinkwitzRileyLowpass", "LinkwitzRileyHighpass"]) {
+      expect(gainAt(filter("BiquadCombo", { type, order, freq: 1000.0 }), [1000.0])[0]).toBeCloseTo(
+        2 * HALF_POWER_DB,
+        6,
+      )
+    }
+  })
+
+  it.each([4, 8])("the two halves of a Linkwitz-Riley of order %d sum flat", (order) => {
+    // This is the property the alignment exists for: the branches recombine to
+    // an allpass, so their sum has unity magnitude at every frequency.
+    const freqs = Float64Array.from(SWEEP)
+    const low = complexGain(filter("BiquadCombo", { type: "LinkwitzRileyLowpass", order, freq: 1000.0 }), FS, 0, freqs)
+    const high = complexGain(
+      filter("BiquadCombo", { type: "LinkwitzRileyHighpass", order, freq: 1000.0 }),
+      FS,
+      0,
+      freqs,
+    )
+    for (let n = 0; n < freqs.length; n++) {
+      const magnitude = Math.hypot(low.re[n] + high.re[n], low.im[n] + high.im[n])
+      expect(magnitude).toBeCloseTo(1.0, 9)
+    }
+  })
+
+  it.each([1, 2, 3, 4, 5, 6, 7, 8])("a Butterworth of order %d has the Butterworth magnitude", (order) => {
+    // |H|^2 = 1 / (1 + (f/f0)^2N) is what makes a filter a Butterworth. The
+    // bilinear transform warps the frequency axis, and matches the analog
+    // prototype at f0, so the comparison is made on the warped axis where the
+    // property is exact rather than asymptotic.
+    const freq = 500.0
+    const warped = (f: number) => Math.tan((Math.PI * f) / FS) / Math.tan((Math.PI * freq) / FS)
+    const freqs = [60.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
+
+    const lowpass = gainAt(filter("BiquadCombo", { type: "ButterworthLowpass", order, freq }), freqs)
+    lowpass.forEach((gain, n) => {
+      expect(gain).toBeCloseTo(-10 * Math.log10(1 + warped(freqs[n]) ** (2 * order)), 6)
+    })
+
+    const highpass = gainAt(filter("BiquadCombo", { type: "ButterworthHighpass", order, freq }), freqs)
+    highpass.forEach((gain, n) => {
+      expect(gain).toBeCloseTo(-10 * Math.log10(1 + warped(freqs[n]) ** (-2 * order)), 6)
+    })
+  })
+})
+
+describe("a delay is a delay, in whichever unit it is given", () => {
+  // 12 samples at 48 kHz is 0.25 ms, 250 us, 0.00025 s, and 85.75 mm of air.
+  const TWELVE_SAMPLES_MS = (12 / FS) * 1000.0
+  it.each([
+    ["samples", 12.0],
+    ["ms", TWELVE_SAMPLES_MS],
+    ["us", TWELVE_SAMPLES_MS * 1000.0],
+    ["s", TWELVE_SAMPLES_MS / 1000.0],
+    ["mm", TWELVE_SAMPLES_MS * 343.0],
+  ])("%s", (delay_unit, delay) => {
+    const freqs = Array.from({ length: 200 }, (_, n) => 20.0 + n * 20.0)
+    const delays = groupDelay(filter("Delay", { delay, delay_unit }), freqs)
+    delays.forEach((value) => expect(value).toBeCloseTo(TWELVE_SAMPLES_MS, 9))
+  })
+
+  it("resolves a fractional delay with the subsample allpass", () => {
+    // The allpass is accurate at low frequencies, which is where it is judged.
+    const freqs = Array.from({ length: 40 }, (_, n) => 20.0 + n * 20.0)
+    for (const samples of [0.5, 3.25, 7.75]) {
+      const delays = groupDelay(filter("Delay", { delay: samples, delay_unit: "samples", subsample: true }), freqs)
+      const expected = (samples / FS) * 1000.0
+      delays.forEach((value) => expect(value).toBeCloseTo(expected, 3))
+    }
+  })
+
+  it("has no effect at all when it is zero", () => {
+    const freqs = [100.0, 1000.0, 10000.0]
+    gainAt(filter("Delay", { delay: 0.0, delay_unit: "ms" }), freqs).forEach((gain) => expect(gain).toBeCloseTo(0, 12))
+    phaseDegrees(
+      complexGain(filter("Delay", { delay: 0.0, delay_unit: "ms" }), FS, 0, Float64Array.from(freqs)),
+    ).forEach((phase) => expect(phase).toBe(0))
+  })
+})
+
+describe("Gain", () => {
+  it.each([-20.0, -6.0, 0.0, 6.0])("a dB gain of %d is flat at that level", (gain) => {
+    gainAt(filter("Gain", { gain, scale: "dB" }), SWEEP).forEach((value) => expect(value).toBeCloseTo(gain, 9))
+  })
+
+  it("a linear gain of 0.5 is 6 dB down", () => {
+    gainAt(filter("Gain", { gain: 0.5, scale: "linear" }), SWEEP).forEach((value) =>
+      expect(value).toBeCloseTo(20 * Math.log10(0.5), 9),
+    )
+  })
+
+  it("inverting flips the phase without touching the magnitude", () => {
+    const freqs = Float64Array.from([100.0, 1000.0, 10000.0])
+    const plain = complexGain(filter("Gain", { gain: -6.0 }), FS, 0, freqs)
+    const inverted = complexGain(filter("Gain", { gain: -6.0, inverted: true }), FS, 0, freqs)
+    magnitudeDb(plain).forEach((value, n) => expect(value).toBeCloseTo(magnitudeDb(inverted)[n], 12))
+    phaseDegrees(inverted).forEach((phase) => expect(Math.abs(phase)).toBeCloseTo(180.0, 9))
+  })
+})
+
+describe("Loudness", () => {
+  it("scales its boost linearly with how far below the reference level it sits", () => {
+    // Full boost at 20 dB below the reference, none at or above it, and half
+    // way in between.
+    const f = filter("Loudness", { reference_level: 0.0, low_boost: 10.0, high_boost: 10.0 })
+    // read at DC, where the low shelf is exactly at its gain and the high
+    // shelf exactly at unity
+    const at = (volume: number) => magnitudeDb(complexGain(f, FS, volume, Float64Array.from([0.0])))[0]
+    expect(at(0.0)).toBeCloseTo(0.0, 9)
+    expect(at(-10.0)).toBeCloseTo(5.0, 9)
+    expect(at(-20.0)).toBeCloseTo(10.0, 9)
+    // clamped, not extrapolated
+    expect(at(-40.0)).toBeCloseTo(10.0, 9)
+  })
+})

--- a/src/camilladsp/eval/properties.test.ts
+++ b/src/camilladsp/eval/properties.test.ts
@@ -15,11 +15,11 @@
  */
 import { describe, expect, it } from "vitest"
 import { Filter } from "../config"
-import { magnitudeDb, phaseDegrees } from "./complex"
-import { convComplexGain } from "./conv"
-import { complexGain } from "./filters"
+import { magnitudeDb, multiplyInto, phaseDegrees } from "./complex"
+import { convComplexGain, convGroupDelay } from "./conv"
+import { complexGain, groupDelaySamples } from "./filters"
+import { delayInMs } from "./groupdelay"
 import { logspace } from "./index"
-import { calcGroupDelay } from "./unwrap"
 
 const FS = 48000
 
@@ -36,8 +36,7 @@ function gainAt(f: Filter, freqs: number[]): number[] {
 
 /** Group delay in ms across the sweep, from the same path the plots use. */
 function groupDelay(f: Filter, freqs: number[]): number[] {
-  const curve = complexGain(f, FS, 0.0, Float64Array.from(freqs))
-  return calcGroupDelay(freqs, phaseDegrees(curve)).groupdelay
+  return delayInMs(groupDelaySamples(f, FS, 0.0, Float64Array.from(freqs)), FS)
 }
 
 const HALF_POWER_DB = 20 * Math.log10(1 / Math.SQRT2)
@@ -278,6 +277,90 @@ describe("Loudness", () => {
   })
 })
 
+describe("group delay comes from the coefficients, not from the phase", () => {
+  /**
+   * The delay in ms at one frequency, from the slope of the phase either side
+   * of it. The check the exact formula has to answer to: differentiating the
+   * phase by hand is what group delay means, and on a fine linear grid, well
+   * away from any null, doing it numerically is accurate enough to pin the
+   * closed form to several digits.
+   */
+  function slopeOfPhase(f: Filter, freq: number): number {
+    const h = 0.05
+    const [below, above] = phaseDegrees(complexGain(f, FS, 0.0, Float64Array.from([freq - h, freq + h])))
+    let step = above - below
+    // the pair straddles a wrap at most once, and never at these spacings
+    // unless the filter has a large delay in it
+    if (step > 180.0) step -= 360.0
+    else if (step < -180.0) step += 360.0
+    return (-step / (2.0 * h) / 360.0) * 1000.0
+  }
+
+  const cases: [string, Filter][] = [
+    ["Butterworth lowpass", filter("BiquadCombo", { type: "ButterworthLowpass", order: 6, freq: 800.0 })],
+    ["peaking", filter("Biquad", { type: "Peaking", freq: 1000.0, q: 4.0, gain: 8.0 })],
+    ["low shelf", filter("Biquad", { type: "Lowshelf", freq: 300.0, q: 0.7, gain: -6.0 })],
+    ["allpass", filter("Biquad", { type: "Allpass", freq: 2000.0, q: 1.5 })],
+    ["subsample delay", filter("Delay", { delay: 3.7, delay_unit: "samples", subsample: true })],
+    ["DiffEq", filter("DiffEq", { a: [1.0, -0.4, 0.2], b: [0.5, 0.3, -0.1] })],
+    ["Tilt", filter("BiquadCombo", { type: "Tilt", gain: 6.0 })],
+  ]
+
+  it.each(cases)("%s", (_name, f) => {
+    const freqs = [50.0, 200.0, 700.0, 1000.0, 3000.0, 9000.0]
+    const exact = groupDelay(f, freqs)
+    freqs.forEach((freq, n) => expect(exact[n]).toBeCloseTo(slopeOfPhase(f, freq), 6))
+  })
+
+  it("walks up to a notch without the singularity spreading", () => {
+    // The zero sits on the unit circle: the magnitude is a true null and the
+    // phase turns through 180 degrees across it. The delay either side does not
+    // turn with it, because a Notch's numerator is symmetric and contributes
+    // exactly its centre tap, one sample, however deep the null. Only the point
+    // that lands on the zero itself is lost, and it is lost to floating point
+    // rather than to the mathematics: 0/0 is a gap, not a spike.
+    const freq = 1000.0
+    const notch = filter("Biquad", { type: "Notch", freq, q: 2.0 })
+    expect(Number.isFinite(groupDelay(notch, [freq])[0])).toBe(false)
+    // a Hz either side it is the slope of the phase, as everywhere else
+    const outside = [freq - 1.0, freq + 1.0]
+    groupDelay(notch, outside).forEach((delay, n) => expect(delay).toBeCloseTo(slopeOfPhase(notch, outside[n]), 6))
+    // and it is continuous across the zero itself: a thousandth of a Hz either
+    // side of it, with the 180 degree jump in between, the two agree to what
+    // the curve genuinely changes by over that distance
+    const [justBelow, justAbove] = groupDelay(notch, [freq - 0.001, freq + 0.001])
+    expect(justBelow).toBeCloseTo(justAbove, 4)
+  })
+
+  it("adds up along a cascade", () => {
+    // Filters multiply and delays add, which is what lets a whole pipeline step
+    // be summed rather than differentiated back out of the product's phase.
+    const freqs = [100.0, 1000.0, 5000.0]
+    const one = filter("Biquad", { type: "Peaking", freq: 1000.0, q: 2.0, gain: 6.0 })
+    const two = filter("Delay", { delay: 2.0, delay_unit: "ms" })
+    const both = filter("DiffEq", { a: [1.0], b: [0.0, 0.0, 1.0] })
+    const sum = groupDelay(one, freqs).map((d, n) => d + groupDelay(two, freqs)[n] + groupDelay(both, freqs)[n])
+    const product = complexGain(one, FS, 0.0, Float64Array.from(freqs))
+    multiplyInto(product, complexGain(two, FS, 0.0, Float64Array.from(freqs)))
+    multiplyInto(product, complexGain(both, FS, 0.0, Float64Array.from(freqs)))
+    // the sum is the delay of the product, checked against the product's own phase
+    freqs.forEach((freq, n) => {
+      const h = 0.05
+      const pair = [freq - h, freq + h]
+      const curves = [one, two, both].map((f) => complexGain(f, FS, 0.0, Float64Array.from(pair)))
+      const total = curves.reduce((acc, curve) => {
+        multiplyInto(acc, curve)
+        return acc
+      })
+      const [pbelow, pabove] = phaseDegrees(total)
+      let step = pabove - pbelow
+      while (step > 180.0) step -= 360.0
+      while (step < -180.0) step += 360.0
+      expect(sum[n]).toBeCloseTo((-step / (2.0 * h) / 360.0) * 1000.0, 6)
+    })
+  })
+})
+
 describe("Conv", () => {
   // The only closed form checks the convolution path has: the FFT, the peak
   // search, the delay removal and the interpolation onto the log grid are
@@ -289,9 +372,8 @@ describe("Conv", () => {
   const FREQS = Array.from(logspace(10.0, (0.95 * FS) / 2, 1000))
 
   /** The group delay in ms of an impulse response, as a whole step plots it. */
-  function convGroupDelay(impulse: number[], removeDelay = false): number[] {
-    const curve = convComplexGain(impulse, FS, FREQS, removeDelay)
-    return calcGroupDelay(FREQS, phaseDegrees(curve)).groupdelay
+  function convDelayMs(impulse: number[], removeDelay = false): number[] {
+    return delayInMs(convGroupDelay(impulse, FS, FREQS, removeDelay), FS)
   }
 
   function impulseAt(index: number, amplitude = 1.0): number[] {
@@ -324,7 +406,7 @@ describe("Conv", () => {
     for (const n of [1, 37, 200, 1000, 20000]) {
       const impulse = impulseAt(n)
       magnitudeDb(convComplexGain(impulse, FS, FREQS)).forEach((gain) => expect(gain).toBeCloseTo(0.0, 6))
-      convGroupDelay(impulse).forEach((delay) => expect(delay).toBeCloseTo((n / FS) * 1000.0, 9))
+      convDelayMs(impulse).forEach((delay) => expect(delay).toBeCloseTo((n / FS) * 1000.0, 9))
     }
   })
 
@@ -333,13 +415,18 @@ describe("Conv", () => {
     // the peak, so the same impulse comes back with no delay at all. The
     // rotation happens on the FFT's own grid, where it cancels exactly.
     for (const n of [1, 37, 200, 500, 20000]) {
-      convGroupDelay(impulseAt(n), true).forEach((delay) => expect(delay).toBeCloseTo(0.0, 9))
+      convDelayMs(impulseAt(n), true).forEach((delay) => expect(delay).toBeCloseTo(0.0, 9))
     }
   })
 
   it("has the constant group delay of its centre tap when it is symmetric", () => {
     // A symmetric FIR is linear phase by construction, so its group delay is
     // half its length whatever its magnitude response does.
+    //
+    // At every frequency, stopband nulls included, which is the property that
+    // reading the delay off the phase could not deliver: `Re(G/H)` works out to
+    // the centre tap plus a term that is purely imaginary, so the singularity
+    // at a null lands entirely in the part this throws away.
     const taps = 257
     const centre = (taps - 1) / 2
     const cutoff = 0.15
@@ -348,16 +435,16 @@ describe("Conv", () => {
       const sinc = k === 0 ? 2 * cutoff : Math.sin(2 * Math.PI * cutoff * k) / (Math.PI * k)
       return sinc * (0.5 - 0.5 * Math.cos((2 * Math.PI * n) / (taps - 1)))
     })
-    // in the passband only: the phase of a stopband null is not meaningful
-    const passband = FREQS.filter((f) => f < 0.5 * cutoff * FS).length
     const expected = (centre / FS) * 1000.0
-    convGroupDelay(impulse)
-      .slice(0, passband)
-      .forEach((delay) => expect(delay).toBeCloseTo(expected, 9))
+    const passband = FREQS.filter((f) => f < 0.5 * cutoff * FS).length
+    const delays = convDelayMs(impulse)
+    delays.slice(0, passband).forEach((delay) => expect(delay).toBeCloseTo(expected, 9))
+    // Across the nulls as well, where the ratio is a small number over a small
+    // number and the cancellation costs a few digits. A nanosecond of them, not
+    // the whole turns of the grid that reading it off the phase was worth.
+    delays.forEach((delay) => expect(Math.abs(delay - expected)).toBeLessThan(1e-6))
     // and the peak search finds that centre tap, so removing the delay flattens it
-    convGroupDelay(impulse, true)
-      .slice(0, passband)
-      .forEach((delay) => expect(delay).toBeCloseTo(0.0, 9))
+    convDelayMs(impulse, true).forEach((delay) => expect(Math.abs(delay)).toBeLessThan(1e-6))
   })
 
   it("matches the definition of the transform, wherever the impulse sits", () => {

--- a/src/camilladsp/eval/properties.test.ts
+++ b/src/camilladsp/eval/properties.test.ts
@@ -16,7 +16,9 @@
 import { describe, expect, it } from "vitest"
 import { Filter } from "../config"
 import { magnitudeDb, phaseDegrees } from "./complex"
+import { convComplexGain } from "./conv"
 import { complexGain } from "./filters"
+import { logspace } from "./index"
 import { calcGroupDelay } from "./unwrap"
 
 const FS = 48000
@@ -45,6 +47,18 @@ describe("a notch is a true zero at its centre frequency", () => {
     // The zero sits exactly on the unit circle, so the response there is not
     // merely small, it is zero to within the floor the plot adds.
     expect(gainAt(filter("Biquad", { type: "Notch", freq, q: 2.0 }), [freq])[0]).toBeLessThan(-200.0)
+  })
+
+  it("does not let its singular group delay spoil the rest of the curve", () => {
+    // The zero sits on the unit circle, so the group delay there is genuinely
+    // singular and whatever lands on that one point is arbitrary. What must not
+    // happen is the rest of the curve following it: predicting each phase step
+    // from a single wild neighbour would put a whole turn into every point
+    // after it, and the curve would never come back.
+    const freqs = Array.from(logspace(10.0, (0.95 * FS) / 2, 1000))
+    const delays = groupDelay(filter("Biquad", { type: "Notch", freq: 1000.0, q: 2.0 }), freqs)
+    const above = delays.filter((_, n) => freqs[n] > 5000.0)
+    above.forEach((delay) => expect(Math.abs(delay)).toBeLessThan(0.01))
   })
 
   it("leaves everything well away from the notch alone", () => {
@@ -207,6 +221,18 @@ describe("a delay is a delay, in whichever unit it is given", () => {
     }
   })
 
+  it.each([10.0, 50.0, 200.0, 1000.0])("is exact at %d ms, however fast the phase turns", (ms) => {
+    // On the log grid the plots use, the step at 20 kHz is over 150 Hz, so a
+    // delay of 50 ms turns the phase through more than 20 whole circles from
+    // one point to the next. Group delay is read off the phase step directly,
+    // predicting each step from the delay just below it in frequency, so a
+    // constant delay comes out exact whatever its size.
+    const freqs = Array.from(logspace(10.0, (0.95 * FS) / 2, 1000))
+    groupDelay(filter("Delay", { delay: ms, delay_unit: "ms" }), freqs).forEach((delay) =>
+      expect(delay).toBeCloseTo(ms, 9),
+    )
+  })
+
   it("has no effect at all when it is zero", () => {
     const freqs = [100.0, 1000.0, 10000.0]
     gainAt(filter("Delay", { delay: 0.0, delay_unit: "ms" }), freqs).forEach((gain) => expect(gain).toBeCloseTo(0, 12))
@@ -249,5 +275,162 @@ describe("Loudness", () => {
     expect(at(-20.0)).toBeCloseTo(10.0, 9)
     // clamped, not extrapolated
     expect(at(-40.0)).toBeCloseTo(10.0, 9)
+  })
+})
+
+describe("Conv", () => {
+  // The only closed form checks the convolution path has: the FFT, the peak
+  // search, the delay removal and the interpolation onto the log grid are
+  // otherwise covered by nothing.
+  //
+  // Evaluated on the grid the plots actually use, because the phase of a
+  // delayed impulse advances quickly and the unwrap needs the slope to build
+  // up gradually, which is what a log grid starting at 10 Hz gives it.
+  const FREQS = Array.from(logspace(10.0, (0.95 * FS) / 2, 1000))
+
+  /** The group delay in ms of an impulse response, as a whole step plots it. */
+  function convGroupDelay(impulse: number[], removeDelay = false): number[] {
+    const curve = convComplexGain(impulse, FS, FREQS, removeDelay)
+    return calcGroupDelay(FREQS, phaseDegrees(curve)).groupdelay
+  }
+
+  function impulseAt(index: number, amplitude = 1.0): number[] {
+    const impulse = new Array<number>(index + 1).fill(0.0)
+    impulse[index] = amplitude
+    return impulse
+  }
+
+  it("passes everything at unity when it is a single unit impulse", () => {
+    magnitudeDb(convComplexGain(impulseAt(0), FS, FREQS)).forEach((gain) => expect(gain).toBeCloseTo(0.0, 9))
+  })
+
+  it("is flat at the gain of a scaled impulse", () => {
+    for (const amplitude of [0.25, 2.0]) {
+      const gains = magnitudeDb(convComplexGain(impulseAt(0, amplitude), FS, FREQS))
+      gains.forEach((gain) => expect(gain).toBeCloseTo(20 * Math.log10(amplitude), 9))
+    }
+  })
+
+  it("delays by N samples when its impulse sits at sample N", () => {
+    // Flat magnitude and exactly N/fs of group delay, which is what makes this
+    // a pure delay rather than merely something that looks like one. Exactly,
+    // because the phase of a delay is linear and interpolating a straight line
+    // is lossless: this is the assertion that caught the index mapping in
+    // `interpolate` reading a fifth of a percent off in frequency.
+    //
+    // The long ones matter as much as the short: 20000 samples is 417 ms, whose
+    // phase turns through nearly a hundred whole circles between two points at
+    // the top of the plot grid.
+    for (const n of [1, 37, 200, 1000, 20000]) {
+      const impulse = impulseAt(n)
+      magnitudeDb(convComplexGain(impulse, FS, FREQS)).forEach((gain) => expect(gain).toBeCloseTo(0.0, 6))
+      convGroupDelay(impulse).forEach((delay) => expect(delay).toBeCloseTo((n / FS) * 1000.0, 9))
+    }
+  })
+
+  it("takes that delay back out when asked to remove it", () => {
+    // The single filter plot rotates the bulk delay out, by the position of
+    // the peak, so the same impulse comes back with no delay at all. The
+    // rotation happens on the FFT's own grid, where it cancels exactly.
+    for (const n of [1, 37, 200, 500, 20000]) {
+      convGroupDelay(impulseAt(n), true).forEach((delay) => expect(delay).toBeCloseTo(0.0, 9))
+    }
+  })
+
+  it("has the constant group delay of its centre tap when it is symmetric", () => {
+    // A symmetric FIR is linear phase by construction, so its group delay is
+    // half its length whatever its magnitude response does.
+    const taps = 257
+    const centre = (taps - 1) / 2
+    const cutoff = 0.15
+    const impulse = Array.from({ length: taps }, (_, n) => {
+      const k = n - centre
+      const sinc = k === 0 ? 2 * cutoff : Math.sin(2 * Math.PI * cutoff * k) / (Math.PI * k)
+      return sinc * (0.5 - 0.5 * Math.cos((2 * Math.PI * n) / (taps - 1)))
+    })
+    // in the passband only: the phase of a stopband null is not meaningful
+    const passband = FREQS.filter((f) => f < 0.5 * cutoff * FS).length
+    const expected = (centre / FS) * 1000.0
+    convGroupDelay(impulse)
+      .slice(0, passband)
+      .forEach((delay) => expect(delay).toBeCloseTo(expected, 9))
+    // and the peak search finds that centre tap, so removing the delay flattens it
+    convGroupDelay(impulse, true)
+      .slice(0, passband)
+      .forEach((delay) => expect(delay).toBeCloseTo(0.0, 9))
+  })
+
+  it("matches the definition of the transform, wherever the impulse sits", () => {
+    // The transfer function of an FIR filter is the sum of h[n] exp(-j w n), so
+    // that sum is the answer, with no FFT, no interpolation and no unwrapping
+    // anywhere near it. An impulse late in a long response is the case that
+    // fails if the bulk delay is not taken out before the phase is unwrapped
+    // on the FFT grid, since the phase then turns by most of a circle from one
+    // bin to the next.
+    for (const peak of [3, 400, 700, 900]) {
+      const h = new Array<number>(1000).fill(0.0)
+      h[peak] = 1.0
+      h[peak + 1] = 0.5
+      h[peak + 2] = -0.25
+      const curve = convComplexGain(h, FS, FREQS)
+      const magnitude = magnitudeDb(curve)
+      const phase = phaseDegrees(curve)
+      FREQS.forEach((f, i) => {
+        let re = 0.0
+        let im = 0.0
+        for (let n = 0; n < h.length; n++) {
+          const w = (-2.0 * Math.PI * f * n) / FS
+          re += h[n] * Math.cos(w)
+          im += h[n] * Math.sin(w)
+        }
+        expect(magnitude[i]).toBeCloseTo(20 * Math.log10(Math.hypot(re, im)), 6)
+        const exact = Math.atan2(im, re) * (180.0 / Math.PI)
+        const off = Math.abs(phase[i] - exact) % 360.0
+        expect(Math.min(off, 360.0 - off)).toBeLessThan(1e-6)
+      })
+    }
+  })
+
+  it("draws the knee of a highpass where it really is", () => {
+    // The case the plot grid is hardest on: a log axis puts hundreds of points
+    // below 100 Hz, so the FFT has to resolve that region rather than have it
+    // interpolated across. Compared against the exact transform, and only
+    // where the response means something: a highpass stopband is full of nulls
+    // that fall between any two bins, and no sampled representation has them.
+    const taps = 2001
+    const centre = (taps - 1) / 2
+    const fc = 80.0 / FS
+    const h = Array.from({ length: taps }, (_, n) => {
+      const k = n - centre
+      const lowpass = k === 0 ? 2 * fc : Math.sin(2 * Math.PI * fc * k) / (Math.PI * k)
+      const window = 0.54 - 0.46 * Math.cos((2 * Math.PI * n) / (taps - 1))
+      return ((k === 0 ? 1 : 0) - lowpass) * window
+    })
+    const magnitude = magnitudeDb(convComplexGain(h, FS, FREQS))
+    let compared = 0
+    FREQS.forEach((f, i) => {
+      let re = 0.0
+      let im = 0.0
+      for (let n = 0; n < taps; n++) {
+        const w = (-2.0 * Math.PI * f * n) / FS
+        re += h[n] * Math.cos(w)
+        im += h[n] * Math.sin(w)
+      }
+      const exact = 20 * Math.log10(Math.hypot(re, im))
+      if (exact < -40) return
+      compared++
+      expect(magnitude[i]).toBeCloseTo(exact, 1)
+    })
+    // the knee is in there, not just the flat top
+    expect(FREQS.filter((f, i) => f < 200 && magnitude[i] > -40).length).toBeGreaterThan(20)
+    expect(compared).toBeGreaterThan(500)
+  })
+
+  it("has the sum of its coefficients as its gain at low frequency", () => {
+    // At DC the transfer function is just the sum, and the first plotted point
+    // sits close enough to DC for the interpolation to show it.
+    const impulse = [0.5, 0.25, 0.125, 0.0625]
+    const sum = impulse.reduce((total, value) => total + value, 0.0)
+    expect(magnitudeDb(convComplexGain(impulse, FS, [1.0]))[0]).toBeCloseTo(20 * Math.log10(sum), 3)
   })
 })

--- a/src/camilladsp/eval/unwrap.ts
+++ b/src/camilladsp/eval/unwrap.ts
@@ -12,15 +12,15 @@
  * unwrap that compares raw steps against 180 degrees is limited to 180 degrees
  * per point by construction, so it is not a replacement.
  *
- * The threshold bounds the prediction error, not the raw step. On smoothly
- * varying phase its exact value makes no difference. The only filter it
- * affects is a Notch, whose zero sits on the unit circle: the phase step
- * across the notch lands just under 180 degrees on a discrete frequency grid,
- * so a threshold of 180 would sit right on the boundary of a genuine 180
- * degree flip. Group delay is singular at the zero either way, and 150 is what
- * keeps the resulting spike positive rather than negative.
+ * The threshold bounds the prediction error, not the raw step, so on smoothly
+ * varying phase its exact value makes little difference.
+ *
+ * This is used for one thing: making a convolution filter's phase continuous
+ * on the FFT's own uniform grid, so that it can be interpolated onto the plot
+ * grid. Group delay does not go through here, it differentiates the phase
+ * directly, see `calcGroupDelay`.
  */
-export function unwrapPhase(values: ArrayLike<number>, threshold = 150.0): Float64Array {
+export function unwrapPhase(values: ArrayLike<number>, threshold: number): Float64Array {
   const unwrapped = new Float64Array(values.length)
   if (values.length === 0) return unwrapped
   let offset = 0
@@ -45,24 +45,72 @@ export function unwrapPhase(values: ArrayLike<number>, threshold = 150.0): Float
   return unwrapped
 }
 
+/** The middle of three values. */
+function median3(values: number[]): number {
+  const [a, b, c] = values
+  return Math.max(Math.min(a, b), Math.min(Math.max(a, b), c))
+}
+
 /**
  * Group delay in ms, from a phase curve in degrees. Returned on the midpoints
  * of the frequency grid, so one point shorter than the input.
+ *
+ * The phase is differentiated directly rather than unwrapped first. Only the
+ * step between two neighbouring points matters here, and a step is known
+ * modulo a full turn, so the whole turns are chosen to land as close as
+ * possible to the group delay just below in frequency. Group delay varies
+ * slowly with frequency where it means anything at all, which makes it a far
+ * better thing to predict than the phase itself: on the log grid the plots
+ * use, the phase step at 20 kHz is hundreds of times the step at 10 Hz, so a
+ * filter with any real delay in it turns through several whole circles between
+ * neighbouring points at the top of the range. Unwrapping the phase first got
+ * that wrong for anything past about 10 ms, and got it wrong cumulatively,
+ * because an unwrap carries its error forward into every later point.
+ *
+ * What cannot be resolved either way is a group delay that changes by more
+ * than half a turn of phase between two points, which is 1/(2*df). That is
+ * 3 ms at the top of the plot grid, and it is a bound on the *change*, not on
+ * the delay: a constant delay of any size comes out exact.
+ *
+ * A phase of NaN, which is how a response too deep to be readable is marked,
+ * gives a group delay of NaN either side of it and is left out of the
+ * prediction, so the curve carries on correctly after the gap.
  */
 export function calcGroupDelay(
   freq: ArrayLike<number>,
   phase: ArrayLike<number>,
 ): { freq: number[]; groupdelay: number[] } {
   if (freq.length < 2) return { freq: [], groupdelay: [] }
-  const unwrapped = unwrapPhase(phase)
   const npoints = freq.length - 1
   const freqNew = new Array<number>(npoints)
   const groupdelay = new Array<number>(npoints)
+  // The prediction is the median of the last three, not simply the last one.
+  // A filter with a zero on the unit circle, a Notch or a null in a convolution
+  // filter's response, has a genuinely singular group delay at that frequency,
+  // and predicting the next point from that one spike would put a whole turn
+  // into every point after it, which the curve would then never recover from.
+  // A median steps over a single wild point and keeps the curve either side of
+  // it right. Seeded with zeros, which is safe: the grid is finest at its low
+  // end, where the phase of even a very long delay moves by a fraction of a
+  // degree between points.
+  const recent = [0.0, 0.0, 0.0]
+  let accepted = 0
   for (let n = 0; n < npoints; n++) {
-    const dw = (freq[n + 1] - freq[n]) * 2 * Math.PI
-    const dp = (unwrapped[n + 1] - unwrapped[n]) * (Math.PI / 180.0)
     freqNew[n] = (freq[n] + freq[n + 1]) / 2.0
-    groupdelay[n] = (-1000.0 * dp) / dw
+    const measured = phase[n + 1] - phase[n]
+    if (!Number.isFinite(measured)) {
+      // a blanked phase, too deep below the passband to be readable. There is
+      // no group delay across it, and it must not teach the prediction
+      // anything either.
+      groupdelay[n] = NaN
+      continue
+    }
+    const dw = (freq[n + 1] - freq[n]) * 2 * Math.PI
+    const predicted = (-median3(recent) / 1000.0) * dw * (180.0 / Math.PI)
+    const step = measured + 360.0 * Math.round((predicted - measured) / 360.0)
+    groupdelay[n] = (-1000.0 * step * (Math.PI / 180.0)) / dw
+    recent[accepted % 3] = groupdelay[n]
+    accepted++
   }
   return { freq: freqNew, groupdelay }
 }

--- a/src/camilladsp/eval/unwrap.ts
+++ b/src/camilladsp/eval/unwrap.ts
@@ -1,5 +1,10 @@
 /**
- * Phase unwrapping and group delay.
+ * Phase unwrapping.
+ *
+ * Only for making a convolution filter's phase continuous on the FFT grid
+ * before it is interpolated onto the plot grid. The group delay does not come
+ * through here: it is computed from the coefficients instead, see
+ * `groupdelay.ts`.
  */
 
 /**
@@ -17,8 +22,7 @@
  *
  * This is used for one thing: making a convolution filter's phase continuous
  * on the FFT's own uniform grid, so that it can be interpolated onto the plot
- * grid. Group delay does not go through here, it differentiates the phase
- * directly, see `calcGroupDelay`.
+ * grid.
  */
 export function unwrapPhase(values: ArrayLike<number>, threshold: number): Float64Array {
   const unwrapped = new Float64Array(values.length)
@@ -43,74 +47,4 @@ export function unwrapPhase(values: ArrayLike<number>, threshold: number): Float
     if (!jumped) prevdiff = unwrapped[n] - unwrapped[n - 1]
   }
   return unwrapped
-}
-
-/** The middle of three values. */
-function median3(values: number[]): number {
-  const [a, b, c] = values
-  return Math.max(Math.min(a, b), Math.min(Math.max(a, b), c))
-}
-
-/**
- * Group delay in ms, from a phase curve in degrees. Returned on the midpoints
- * of the frequency grid, so one point shorter than the input.
- *
- * The phase is differentiated directly rather than unwrapped first. Only the
- * step between two neighbouring points matters here, and a step is known
- * modulo a full turn, so the whole turns are chosen to land as close as
- * possible to the group delay just below in frequency. Group delay varies
- * slowly with frequency where it means anything at all, which makes it a far
- * better thing to predict than the phase itself: on the log grid the plots
- * use, the phase step at 20 kHz is hundreds of times the step at 10 Hz, so a
- * filter with any real delay in it turns through several whole circles between
- * neighbouring points at the top of the range. Unwrapping the phase first got
- * that wrong for anything past about 10 ms, and got it wrong cumulatively,
- * because an unwrap carries its error forward into every later point.
- *
- * What cannot be resolved either way is a group delay that changes by more
- * than half a turn of phase between two points, which is 1/(2*df). That is
- * 3 ms at the top of the plot grid, and it is a bound on the *change*, not on
- * the delay: a constant delay of any size comes out exact.
- *
- * A phase of NaN, which is how a response too deep to be readable is marked,
- * gives a group delay of NaN either side of it and is left out of the
- * prediction, so the curve carries on correctly after the gap.
- */
-export function calcGroupDelay(
-  freq: ArrayLike<number>,
-  phase: ArrayLike<number>,
-): { freq: number[]; groupdelay: number[] } {
-  if (freq.length < 2) return { freq: [], groupdelay: [] }
-  const npoints = freq.length - 1
-  const freqNew = new Array<number>(npoints)
-  const groupdelay = new Array<number>(npoints)
-  // The prediction is the median of the last three, not simply the last one.
-  // A filter with a zero on the unit circle, a Notch or a null in a convolution
-  // filter's response, has a genuinely singular group delay at that frequency,
-  // and predicting the next point from that one spike would put a whole turn
-  // into every point after it, which the curve would then never recover from.
-  // A median steps over a single wild point and keeps the curve either side of
-  // it right. Seeded with zeros, which is safe: the grid is finest at its low
-  // end, where the phase of even a very long delay moves by a fraction of a
-  // degree between points.
-  const recent = [0.0, 0.0, 0.0]
-  let accepted = 0
-  for (let n = 0; n < npoints; n++) {
-    freqNew[n] = (freq[n] + freq[n + 1]) / 2.0
-    const measured = phase[n + 1] - phase[n]
-    if (!Number.isFinite(measured)) {
-      // a blanked phase, too deep below the passband to be readable. There is
-      // no group delay across it, and it must not teach the prediction
-      // anything either.
-      groupdelay[n] = NaN
-      continue
-    }
-    const dw = (freq[n + 1] - freq[n]) * 2 * Math.PI
-    const predicted = (-median3(recent) / 1000.0) * dw * (180.0 / Math.PI)
-    const step = measured + 360.0 * Math.round((predicted - measured) / 360.0)
-    groupdelay[n] = (-1000.0 * step * (Math.PI / 180.0)) / dw
-    recent[accepted % 3] = groupdelay[n]
-    accepted++
-  }
-  return { freq: freqNew, groupdelay }
 }

--- a/src/camilladsp/eval/unwrap.ts
+++ b/src/camilladsp/eval/unwrap.ts
@@ -1,0 +1,68 @@
+/**
+ * Phase unwrapping and group delay.
+ */
+
+/**
+ * Unwrap a phase curve given in degrees.
+ *
+ * Unlike the usual unwrap, this predicts each value from the previous one plus
+ * the last known slope, and measures the jump against that prediction. That
+ * lets it follow a phase that advances by more than 180 degrees per point, as
+ * a filter with a large delay does, as long as the slope changes gradually. An
+ * unwrap that compares raw steps against 180 degrees is limited to 180 degrees
+ * per point by construction, so it is not a replacement.
+ *
+ * The threshold bounds the prediction error, not the raw step. On smoothly
+ * varying phase its exact value makes no difference. The only filter it
+ * affects is a Notch, whose zero sits on the unit circle: the phase step
+ * across the notch lands just under 180 degrees on a discrete frequency grid,
+ * so a threshold of 180 would sit right on the boundary of a genuine 180
+ * degree flip. Group delay is singular at the zero either way, and 150 is what
+ * keeps the resulting spike positive rather than negative.
+ */
+export function unwrapPhase(values: ArrayLike<number>, threshold = 150.0): Float64Array {
+  const unwrapped = new Float64Array(values.length)
+  if (values.length === 0) return unwrapped
+  let offset = 0
+  let prevdiff = 0.0
+  unwrapped[0] = values[0]
+  for (let n = 1; n < values.length; n++) {
+    const guess = values[n - 1] + prevdiff
+    const diff = values[n] - guess
+    let jumped: boolean
+    if (diff > threshold) {
+      offset -= 1
+      jumped = true
+    } else if (diff < -threshold) {
+      offset += 1
+      jumped = true
+    } else {
+      jumped = false
+    }
+    unwrapped[n] = values[n] + 2 * 180.0 * offset
+    if (!jumped) prevdiff = unwrapped[n] - unwrapped[n - 1]
+  }
+  return unwrapped
+}
+
+/**
+ * Group delay in ms, from a phase curve in degrees. Returned on the midpoints
+ * of the frequency grid, so one point shorter than the input.
+ */
+export function calcGroupDelay(
+  freq: ArrayLike<number>,
+  phase: ArrayLike<number>,
+): { freq: number[]; groupdelay: number[] } {
+  if (freq.length < 2) return { freq: [], groupdelay: [] }
+  const unwrapped = unwrapPhase(phase)
+  const npoints = freq.length - 1
+  const freqNew = new Array<number>(npoints)
+  const groupdelay = new Array<number>(npoints)
+  for (let n = 0; n < npoints; n++) {
+    const dw = (freq[n + 1] - freq[n]) * 2 * Math.PI
+    const dp = (unwrapped[n + 1] - unwrapped[n]) * (Math.PI / 180.0)
+    freqNew[n] = (freq[n] + freq[n + 1]) / 2.0
+    groupdelay[n] = (-1000.0 * dp) / dw
+  }
+  return { freq: freqNew, groupdelay }
+}

--- a/src/camilladsp/eval/variants.test.ts
+++ b/src/camilladsp/eval/variants.test.ts
@@ -33,7 +33,8 @@ describe("every schema valid filter evaluates", () => {
     })
     expect(result.magnitude!.length).toBe(64)
     expect(result.phase!.length).toBe(64)
-    expect(result.groupdelay!.length).toBe(63)
+    // one value per plot point, not one per midpoint between two of them
+    expect(result.groupdelay!.length).toBe(64)
     expect(result.magnitude!.every(Number.isFinite), "magnitude is finite everywhere").toBe(true)
     expect(result.phase!.every(Number.isFinite), "phase is finite everywhere").toBe(true)
     expect(result.groupdelay!.every(Number.isFinite), "group delay is finite everywhere").toBe(true)

--- a/src/camilladsp/eval/variants.test.ts
+++ b/src/camilladsp/eval/variants.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Every filter config the schemas allow must evaluate.
+ *
+ * The schemas live in the backend, in Python, while the evaluator lives here.
+ * `camillagui-backend/tools/dump_filter_variants.py` exports one config per
+ * schema variant so that the two stay coupled: a new filter parameter shows up
+ * here as a new variant, and this test fails if the evaluator does not handle
+ * it. The backend's `test_eval_validated_configs.py` fails if the export is
+ * stale, so neither side can drift on its own.
+ *
+ * Each variant appears twice, as the user writes it and again after the
+ * validator has filled in the schema defaults, which is where optional
+ * parameters turn into explicit nulls.
+ *
+ * This checks that the evaluator copes, not what it computes. The numbers are
+ * pinned by golden.test.ts.
+ */
+import { describe, expect, it } from "vitest"
+import { Filter } from "../config"
+import variants from "./fixtures/variants.json"
+import { evalFilter } from "./index"
+
+const cases = variants.variants as unknown as { id: string; filter: Filter }[]
+
+describe("every schema valid filter evaluates", () => {
+  it.each(cases.map((variant) => [variant.id, variant] as const))("%s", async (_id, variant) => {
+    const result = await evalFilter(variant.filter, {
+      name: variant.id,
+      samplerate: 48000,
+      channels: 2,
+      volume: variants.volume,
+      npoints: 64,
+    })
+    expect(result.magnitude!.length).toBe(64)
+    expect(result.phase!.length).toBe(64)
+    expect(result.groupdelay!.length).toBe(63)
+    expect(result.magnitude!.every(Number.isFinite), "magnitude is finite everywhere").toBe(true)
+    expect(result.phase!.every(Number.isFinite), "phase is finite everywhere").toBe(true)
+    expect(result.groupdelay!.every(Number.isFinite), "group delay is finite everywhere").toBe(true)
+  })
+})

--- a/src/camilladsp/eval/variants.test.ts
+++ b/src/camilladsp/eval/variants.test.ts
@@ -13,7 +13,7 @@
  * parameters turn into explicit nulls.
  *
  * This checks that the evaluator copes, not what it computes. The numbers are
- * pinned by golden.test.ts.
+ * covered by properties.test.ts.
  */
 import { describe, expect, it } from "vitest"
 import { Filter } from "../config"

--- a/src/custom-pages/README.md
+++ b/src/custom-pages/README.md
@@ -108,7 +108,7 @@ config.description: string | null
 { gain: number, mute?: boolean, scale?: "dB" | "Linear" | "Linear2", inverted?: boolean }
 
 // Delay
-{ delay: number, unit?: "ms" | "samples", subsample?: boolean }
+{ delay: number, delay_unit: "ms" | "us" | "s" | "mm" | "samples", subsample?: boolean }
 
 // Conv (convolution / FIR)
 { type: "Raw" | "Wav" | "Values", filename?: string, values?: number[] }
@@ -201,28 +201,36 @@ const res = await fetch("/api/storedcoeffs")
 const files: string[] = await res.json()
 ```
 
-### POST /api/evalfilter
+### Evaluating a filter
 
-Evaluate a filter's frequency response. Returns magnitude, phase, and optionally group delay for
-plotting. The `name` field is only used as a label in the response.
+Filter evaluation runs in the browser, not on the backend, so it is a plain function call rather
+than an endpoint. Custom pages compile into the app, so they can import it directly.
 
 ```ts
-const res = await fetch("/api/evalfilter", {
-  method: "POST",
-  headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({
-    name: "MyFilter",
-    config: config.filters["MyFilter"],   // the filter definition object
-    samplerate: config.devices.samplerate,
-    channels: config.devices.capture.channels,
-  }),
+import { evalFilter, evalFilterStep } from "../camilladsp/eval"
+
+const data = await evalFilter(config.filters["MyFilter"], {
+  name: "MyFilter",
+  samplerate: config.devices.samplerate,
+  channels: config.devices.capture.channels,
 })
-const data = await res.json()
-// data.freq: number[]        — frequency axis in Hz
-// data.magnitude: number[]   — magnitude in dB at each frequency
-// data.phase: number[]       — phase in radians
-// data.groupdelay: number[]  — group delay in ms (may be absent)
+// data.f: number[]            - frequency axis in Hz
+// data.magnitude: number[]    - magnitude in dB at each frequency
+// data.phase: number[]        - phase in degrees
+// data.f_groupdelay: number[] - frequency axis for the group delay, one point shorter
+// data.groupdelay: number[]   - group delay in ms
+// data.impulse: number[]      - the impulse response, Conv filters only
+
+// The combined response of a whole pipeline step
+const step = await evalFilterStep(config, 0, {
+  samplerate: config.devices.samplerate,
+  channels: config.devices.capture.channels,
+})
 ```
+
+It returns a promise because a Conv filter reading a coefficient file has to ask the backend for
+the coefficients. Everything else resolves without touching the network, so it is cheap enough to
+call on every render.
 
 ### POST /api/setparam/{name}
 
@@ -435,6 +443,7 @@ export default QuickEQ
 ```tsx
 import React, { useEffect, useState } from "react"
 import type { CustomPageProps } from "./types"
+import { evalFilter } from "../camilladsp/eval"
 import { Box } from "../utilities/ui-components"
 
 const FILTER_NAME = "MyLowpass"
@@ -446,21 +455,14 @@ function FilterPlot({ config }: CustomPageProps) {
   useEffect(() => {
     const filter = config.filters[FILTER_NAME]
     if (!filter) return
-    fetch("/api/evalfilter", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        name: FILTER_NAME,
-        config: filter,
-        samplerate: config.devices.samplerate,
-        channels: config.devices.capture.channels,
-      }),
+    evalFilter(filter, {
+      name: FILTER_NAME,
+      samplerate: config.devices.samplerate,
+      channels: config.devices.capture.channels,
+    }).then((data) => {
+      setFreqs(data.f)
+      setMagnitude(data.magnitude ?? null)
     })
-      .then((r) => r.json())
-      .then((data) => {
-        setFreqs(data.freq)
-        setMagnitude(data.magnitude)
-      })
   }, [config])
 
   return (
@@ -495,8 +497,8 @@ export default FilterPlot
   isn't present.
 - **Local state for UI:** Use `useState` freely for things like selected channel, expanded panels,
   or intermediate form values.
-- **Derived data from the DSP:** Call `/api/evalfilter` inside `useEffect` with `config` as a
-  dependency. Re-fetches automatically when the user edits filters elsewhere.
+- **Derived data from the DSP:** Call `evalFilter` inside `useEffect` with `config` as a
+  dependency. Re-evaluates automatically when the user edits filters elsewhere.
 - **Real-time values:** Use `EventSource("/api/events")` for live level meters. Close the source
   in the `useEffect` cleanup to avoid leaks.
 - **TypeScript casts:** Filter parameters are typed as `Record<string, unknown>`. Cast to a

--- a/src/custom-pages/README.md
+++ b/src/custom-pages/README.md
@@ -217,7 +217,7 @@ const data = await evalFilter(config.filters["MyFilter"], {
 // data.f: number[]            - frequency axis in Hz
 // data.magnitude: number[]    - magnitude in dB at each frequency
 // data.phase: number[]        - phase in degrees
-// data.f_groupdelay: number[] - frequency axis for the group delay, one point shorter
+// data.f_groupdelay: number[] - frequency axis for the group delay, the same as data.f
 // data.groupdelay: number[]   - group delay in ms
 // data.impulse: number[]      - the impulse response, Conv filters only
 

--- a/src/demo/mockBackend.ts
+++ b/src/demo/mockBackend.ts
@@ -433,45 +433,32 @@ function captureChannelCount(config: Config) {
   return "channels" in config.devices.capture ? config.devices.capture.channels : 2
 }
 
-function generateChartContent(name: string) {
-  const points = 192
-  const f = Array.from({ length: points }, (_, index) => {
-    const min = Math.log10(20)
-    const max = Math.log10(20000)
-    return 10 ** (min + ((max - min) * index) / (points - 1))
+/**
+ * A synthetic impulse response for demo mode.
+ *
+ * Filter evaluation now runs in the browser, so the demo backend only has to
+ * supply what a real one would: the coefficients behind a Conv filter that
+ * reads a file. The GUI does the FFT and plots the real response of these.
+ */
+function makeConvCoefficients(filename: string) {
+  const taps = 512
+  const nameHash = Array.from(filename).reduce((acc, char) => acc + char.charCodeAt(0), 0)
+  const center = 96
+  const cutoff = 0.15 + (nameHash % 17) / 100
+  const coefficients = Array.from({ length: taps }, (_, index) => {
+    const n = index - center
+    const sinc = n === 0 ? 2 * cutoff : Math.sin(2 * Math.PI * cutoff * n) / (Math.PI * n)
+    // Hann window over the part of the response that carries the impulse
+    const window = index < 2 * center ? 0.5 - 0.5 * Math.cos((Math.PI * index) / center) : 0
+    return sinc * window
   })
-  const nameHash = Array.from(name).reduce((acc, char) => acc + char.charCodeAt(0), 0)
-  const magnitude = f.map((freq, index) => {
-    const sweep = Math.sin(Math.log(freq) * 1.7 + nameHash * 0.03) * 2.5
-    const contour = Math.cos(index / 18 + nameHash * 0.02) * 0.8
-    return Number((sweep + contour).toFixed(3))
-  })
-  const phase = f.map((freq) => Number((Math.sin(Math.log(freq) * 0.9 + nameHash * 0.01) * 70).toFixed(3)))
-  const time = Array.from({ length: 256 }, (_, index) => index / state.currentConfig.devices.samplerate)
-  const impulse = time.map((t, index) => {
-    const center = 18 / state.currentConfig.devices.samplerate
-    const distance = (t - center) * state.currentConfig.devices.samplerate * 0.12
-    const envelope = Math.exp(-(distance ** 2))
-    const ripple = Math.cos(index / 8) * 0.12
-    return Number((envelope + ripple).toFixed(5))
-  })
-  const groupdelay = f.map((freq) => Number((2.5 + Math.sin(Math.log(freq) * 1.3 + nameHash * 0.02) * 0.8).toFixed(3)))
   return {
-    name,
-    samplerate: state.currentConfig.devices.samplerate,
-    channels: captureChannelCount(state.currentConfig),
     options: [
-      { name: "48 kHz stereo", samplerate: 48000, channels: 2 },
-      { name: "96 kHz stereo", samplerate: 96000, channels: 2 },
-      { name: "48 kHz 4 ch", samplerate: 48000, channels: 4 },
+      { name: "48000 Hz - 2 Channels", samplerate: 48000, channels: 2 },
+      { name: "96000 Hz - 2 Channels", samplerate: 96000, channels: 2 },
+      { name: "48000 Hz - 4 Channels", samplerate: 48000, channels: 4 },
     ],
-    f,
-    magnitude,
-    phase,
-    time,
-    impulse,
-    f_groupdelay: f,
-    groupdelay,
+    coefficients,
   }
 }
 
@@ -746,14 +733,9 @@ async function handleApiRequest(input: RequestInfo | URL, init?: RequestInit): P
     return textResponse("OK")
   }
 
-  if (pathname === "/api/evalfilter" && method === "POST") {
-    const payload = await requestJson<{ name?: string }>(input, init)
-    return jsonResponse(generateChartContent(payload.name ?? "Filter response"))
-  }
-
-  if (pathname === "/api/evalfilterstep" && method === "POST") {
-    const payload = await requestJson<{ index?: number }>(input, init)
-    return jsonResponse(generateChartContent(`Pipeline step ${payload.index ?? 0}`))
+  if (pathname === "/api/convcoeffs" && method === "POST") {
+    const payload = await requestJson<{ config?: { parameters?: { filename?: string } } }>(input, init)
+    return jsonResponse(makeConvCoefficients(payload.config?.parameters?.filename ?? "demo"))
   }
 
   if (pathname === "/api/wavinfo" && method === "GET") {

--- a/src/demo/mockBackend.ts
+++ b/src/demo/mockBackend.ts
@@ -440,6 +440,27 @@ function captureChannelCount(config: Config) {
  * supply what a real one would: the coefficients behind a Conv filter that
  * reads a file. The GUI does the FFT and plots the real response of these.
  */
+/**
+ * The same framing the real backend uses for a coefficient reply: a little
+ * endian uint32 header length, that much JSON, padding to a multiple of 8, and
+ * the samples as raw float64. See `_coefficients_response` in the backend and
+ * `unframeCoefficients` in camilladsp/eval.
+ */
+function coefficientsResponse(options: unknown, coefficients: number[]): Response {
+  // float32, as the real backend sends for a wav or raw file of that width
+  const header = new TextEncoder().encode(JSON.stringify({ options, format: "float32" }))
+  const padding = (8 - ((4 + header.length) % 8)) % 8
+  const start = 4 + header.length + padding
+  const buffer = new ArrayBuffer(start + 4 * coefficients.length)
+  new DataView(buffer).setUint32(0, header.length, true)
+  new Uint8Array(buffer, 4, header.length).set(header)
+  new Float32Array(buffer, start).set(coefficients)
+  return new Response(buffer, {
+    status: 200,
+    headers: { "Content-Type": "application/octet-stream" },
+  })
+}
+
 function makeConvCoefficients(filename: string) {
   const taps = 512
   const nameHash = Array.from(filename).reduce((acc, char) => acc + char.charCodeAt(0), 0)
@@ -735,7 +756,8 @@ async function handleApiRequest(input: RequestInfo | URL, init?: RequestInit): P
 
   if (pathname === "/api/convcoeffs" && method === "POST") {
     const payload = await requestJson<{ config?: { parameters?: { filename?: string } } }>(input, init)
-    return jsonResponse(makeConvCoefficients(payload.config?.parameters?.filename ?? "demo"))
+    const { options, coefficients } = makeConvCoefficients(payload.config?.parameters?.filename ?? "demo")
+    return coefficientsResponse(options, coefficients)
   }
 
   if (pathname === "/api/wavinfo" && method === "GET") {

--- a/src/devicestab.tsx
+++ b/src/devicestab.tsx
@@ -38,10 +38,10 @@ import {
   default_to_null,
   EnumInput,
   EnumOption,
-  ERROR_BACKGROUND_STYLE,
   ErrorBoundary,
   ErrorMessage,
   FileSelectPopup,
+  InputWithIcon,
   IntInput,
   IntOption,
   KeyValueSelectPopup,
@@ -1075,38 +1075,24 @@ function CaptureOptions(props: {
       )}
       {(capture.type === "RawFile" || capture.type === "WavFile") && (
         <>
-          <div className="setting" data-tooltip-html="Filename including path" data-tooltip-id="main-tooltip">
-            <label htmlFor="filename" className="setting-label">
-              filename
-            </label>
-            <div className="setting-input device-option-row">
-              <TextInput
-                value={capture.filename}
-                tooltip="Filename including path"
-                className="setting-input device-option-input"
-                style={errors.messageFor("filename") ? ERROR_BACKGROUND_STYLE : undefined}
-                onChange={(filename) => {
-                  if (!props.allowAbsolutePaths && (filename.includes("/") || filename.includes("\\"))) return
-                  onChange((devices) => {
-                    if (devices.capture.type === "RawFile" || devices.capture.type === "WavFile")
-                      devices.capture.filename = filename
-                  })
-                }}
-              />
-              {props.audiofilesSupported && (
-                <div className="device-option-buttons">
-                  <MdiButton
-                    icon={mdiFileSearch}
-                    tooltip="Pick a file"
-                    onClick={() => setCaptureFilePickerOpen(true)}
-                    className="setting-button"
-                    buttonSize="small"
-                  />
-                </div>
-              )}
-            </div>
-            <ErrorMessage message={errors.messageFor("filename")} />
-          </div>
+          <TextOption
+            value={capture.filename}
+            error={errors.messageFor("filename")}
+            desc="filename"
+            tooltip="Filename including path"
+            icon={
+              props.audiofilesSupported
+                ? { path: mdiFileSearch, tooltip: "Pick a file", onClick: () => setCaptureFilePickerOpen(true) }
+                : undefined
+            }
+            onChange={(filename) => {
+              if (!props.allowAbsolutePaths && (filename.includes("/") || filename.includes("\\"))) return
+              onChange((devices) => {
+                if (devices.capture.type === "RawFile" || devices.capture.type === "WavFile")
+                  devices.capture.filename = filename
+              })
+            }}
+          />
           {props.audiofilesSupported && (
             <FileSelectPopup
               open={captureFilePickerOpen}
@@ -1732,22 +1718,10 @@ function DeviceOption(props: {
         {props.desc}
       </label>
       <div className="setting-input device-option-row">
-        <TextInput
-          value={props.value}
-          tooltip="Name of device"
-          className="setting-input device-option-input"
-          onChange={props.onChange}
-        />
-        <div className="device-option-buttons">
-          <MdiButton
-            icon={mdiMagnify}
-            tooltip="Pick a device"
-            onClick={props.onButtonClick}
-            className="setting-button"
-            buttonSize="small"
-          />
-          {props.extraButtons}
-        </div>
+        <InputWithIcon icon={mdiMagnify} tooltip="Pick a device" onClick={props.onButtonClick}>
+          <TextInput value={props.value} tooltip="Name of device" onChange={props.onChange} />
+        </InputWithIcon>
+        {props.extraButtons && <div className="device-option-buttons">{props.extraButtons}</div>}
       </div>
       <ErrorMessage message={props.error} />
     </div>
@@ -1768,22 +1742,10 @@ function OptionalDeviceOption(props: {
         {props.desc}
       </label>
       <div className="setting-input device-option-row">
-        <OptionalTextInput
-          value={props.value}
-          tooltip="Name of device"
-          className="setting-input device-option-input"
-          onChange={props.onChange}
-        />
-        <div className="device-option-buttons">
-          <MdiButton
-            icon={mdiMagnify}
-            tooltip="Pick a device"
-            onClick={props.onButtonClick}
-            className="setting-button"
-            buttonSize="small"
-          />
-          {props.extraButtons}
-        </div>
+        <InputWithIcon icon={mdiMagnify} tooltip="Pick a device" onClick={props.onButtonClick}>
+          <OptionalTextInput value={props.value} tooltip="Name of device" onChange={props.onChange} />
+        </InputWithIcon>
+        {props.extraButtons && <div className="device-option-buttons">{props.extraButtons}</div>}
       </div>
       <ErrorMessage message={props.error} />
     </div>

--- a/src/devicestab.tsx
+++ b/src/devicestab.tsx
@@ -30,8 +30,8 @@ import {
 import { DeviceCapabilities, DeviceCapabilitiesPopup } from "./devicecapabilitiespopup"
 import { CaptureType, GuiConfig, PlaybackType } from "./guiconfig"
 import { Update } from "./utilities/common"
-import { FileInfo, loadFiles } from "./utilities/files"
 import { Errors } from "./utilities/errors"
+import { FileInfo, loadFiles } from "./utilities/files"
 import {
   add_default_option_inplace,
   Box,

--- a/src/filestab.tsx
+++ b/src/filestab.tsx
@@ -13,6 +13,7 @@ import {
 import { ColumnDef } from "@tanstack/react-table"
 import { isEqual } from "lodash"
 import { Config, CURRENT_CONFIG_VERSION, defaultConfig } from "./camilladsp/config"
+import { clearCoefficientCache } from "./camilladsp/eval"
 import { GuiConfig } from "./guiconfig"
 import { ImportPopup, ImportPopupProps } from "./import/importpopup"
 import { PipelinePopup } from "./pipeline/pipelineplotter"
@@ -202,6 +203,15 @@ class FileTable extends Component<
     }
   }
 
+  /**
+   * Drop the cached coefficients after this table has changed the files on
+   * disk. A plot caches what it read by filter name, so a file replaced under
+   * a name already in use would otherwise keep plotting its old contents.
+   */
+  private coefficientFilesChanged() {
+    if (this.type === "coeff") clearCoefficientCache()
+  }
+
   private update() {
     loadFiles(this.type).then((files) => {
       if (!isEqual(files, this.state.files)) {
@@ -221,6 +231,7 @@ class FileTable extends Component<
       body: JSON.stringify(this.state.selectedFiles.map((f) => f.name)),
     })
     this.setState({ fileStatus: null })
+    this.coefficientFilesChanged()
     this.update()
   }
 
@@ -240,6 +251,7 @@ class FileTable extends Component<
       files,
       () => {
         this.showSuccess(EMPTY_FILENAME, "upload")
+        this.coefficientFilesChanged()
         this.update()
       },
       (message) => this.showErrorMessage(EMPTY_FILENAME, "upload", message),
@@ -397,6 +409,7 @@ class FileTable extends Component<
       )
       if (response.ok) {
         this.showSuccess(newName, "rename")
+        this.coefficientFilesChanged()
         this.update()
       } else {
         const message = await response.text()

--- a/src/filterstab.tsx
+++ b/src/filterstab.tsx
@@ -31,7 +31,7 @@ import {
   FilterParameterValue,
   PeqBand,
 } from "./camilladsp/config"
-import { evalFilter } from "./camilladsp/eval"
+import { clearCoefficientCache, evalFilter } from "./camilladsp/eval"
 import { Chart, ChartContent, PlotVolumeSlider } from "./utilities/chart"
 import { modifiedCopyOf, Update } from "./utilities/common"
 import { Errors } from "./utilities/errors"
@@ -333,7 +333,11 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
     }
   }
 
-  /** Only file backed Conv filters go to the backend, and only they need debouncing. */
+  /**
+   * Only a Conv needs debouncing: a file backed one goes to the backend, and
+   * Dummy and Values can carry an impulse response long enough that the FFT is
+   * worth keeping off every keystroke.
+   */
   private timer = delayedExecutor(500)
 
   private uploadCoeffs(files: FileList) {
@@ -343,6 +347,8 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
       (fileNames) => {
         this.setState({ uploadState: { success: true } })
         const { updateAvailableCoeffFiles } = this.props
+        // an upload may have replaced a file the cache still holds coefficients for
+        clearCoefficientCache()
         this.pickFilterFile(fileNames[0])
         updateAvailableCoeffFiles()
       },
@@ -407,9 +413,9 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
         !isEqual(prevFilter.parameters, currentFilter.parameters) ||
         this.state.plot_at_volume !== prevState.plot_at_volume
       ) {
-        // Everything except a Conv reading a coefficient file is evaluated in
-        // the browser, so it can follow the control being dragged directly.
-        if (isConvolutionFileFilter(currentFilter)) this.timer(() => this.plotFilter())
+        // Everything except a Conv is evaluated in the browser from a handful
+        // of coefficients, so it can follow the control being dragged directly.
+        if (currentFilter.type === "Conv") this.timer(() => this.plotFilter())
         else this.plotFilter()
       }
     }

--- a/src/filterstab.tsx
+++ b/src/filterstab.tsx
@@ -458,7 +458,7 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
   }
 
   render() {
-    const { name, filter } = this.props
+    const { name } = this.props
     const uploadState = this.state.uploadState
     const isValidFilterName = (newName: string) =>
       name === newName || (newName.trim().length > 0 && this.props.isFreeFilterName(newName))
@@ -519,13 +519,6 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
               tooltip="Plot frequency response of this filter"
               onClick={this.toggleFilterPlot}
             />
-            {isConvolutionFileFilter(filter) && (
-              <MdiButton
-                icon={mdiFileSearch}
-                tooltip="Pick filter file"
-                onClick={() => this.setState({ filterFilePopupOpen: true })}
-              />
-            )}
             <DeleteButton tooltip={"Delete this filter"} onClick={this.props.remove} />
           </div>
           <FilterParams
@@ -538,6 +531,7 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
             filterDefaults={this.state.filterDefaults}
             showDefaults={this.state.showDefaults}
             setShowDefaults={() => this.setState({ showDefaults: true })}
+            openFilePicker={() => this.setState({ filterFilePopupOpen: true })}
           />
         </div>
 
@@ -635,6 +629,7 @@ interface FilterParamsProps {
   filterDefaults: FilterDefaults
   setShowDefaults: () => void
   showDefaults: boolean
+  openFilePicker: () => void
 }
 
 class FilterParams extends React.Component<FilterParamsProps, unknown> {
@@ -1016,6 +1011,7 @@ class FilterParams extends React.Component<FilterParamsProps, unknown> {
         {...props}
         value={selectedFile}
         error={error}
+        icon={{ path: mdiFileSearch, tooltip: "Pick filter file", onClick: this.props.openFilePicker }}
         onChange={(value) => {
           if (!allowAbsolutePaths && containsPathSeparator(value)) return
           this.props.updateFilter(coeffFileNameUpdate(coeffDir, value))

--- a/src/filterstab.tsx
+++ b/src/filterstab.tsx
@@ -31,6 +31,7 @@ import {
   FilterParameterValue,
   PeqBand,
 } from "./camilladsp/config"
+import { evalFilter } from "./camilladsp/eval"
 import { Chart, ChartContent, PlotVolumeSlider } from "./utilities/chart"
 import { modifiedCopyOf, Update } from "./utilities/common"
 import { Errors } from "./utilities/errors"
@@ -330,9 +331,9 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
         this.updateDefaults(filename)
       }
     }
-    this.plotFilter()
   }
 
+  /** Only file backed Conv filters go to the backend, and only they need debouncing. */
   private timer = delayedExecutor(500)
 
   private uploadCoeffs(files: FileList) {
@@ -405,8 +406,12 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
         prevFilter.type !== currentFilter.type ||
         !isEqual(prevFilter.parameters, currentFilter.parameters) ||
         this.state.plot_at_volume !== prevState.plot_at_volume
-      )
-        this.timer(() => this.plotFilter())
+      ) {
+        // Everything except a Conv reading a coefficient file is evaluated in
+        // the browser, so it can follow the control being dragged directly.
+        if (isConvolutionFileFilter(currentFilter)) this.timer(() => this.plotFilter())
+        else this.plotFilter()
+      }
     }
   }
 
@@ -433,25 +438,16 @@ class FilterView extends React.Component<FilterViewProps, FilterViewState> {
   }
 
   private plotFilter(samplerate?: number, channels?: number) {
-    fetch("/api/evalfilter", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        name: this.props.name,
-        config: this.props.filter,
-        samplerate: samplerate || this.props.samplerate,
-        channels: channels || this.state.channels,
-        volume: this.state.plot_at_volume,
-      }),
+    evalFilter(this.props.filter, {
+      name: this.props.name,
+      samplerate: samplerate || this.props.samplerate,
+      channels: channels || this.state.channels,
+      volume: this.state.plot_at_volume,
     }).then(
-      (result) =>
-        result.json().then(
-          (data) => {
-            if (this.state.showFilterPlot) this.setState({ data: data as ChartContent })
-          },
-          (error) => console.log("JSON parse failed", error),
-        ),
-      (error) => console.log("api call failed", error),
+      (data) => {
+        if (this.state.showFilterPlot) this.setState({ data })
+      },
+      (error) => console.log("Filter evaluation failed", error),
     )
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -405,6 +405,35 @@ textarea.logfileviewer {
   gap: 4px;
 }
 
+.input-with-icon {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+}
+
+.input-with-icon > input {
+  width: 100%;
+  padding-right: 26px;
+}
+
+.input-icon-button {
+  position: absolute;
+  right: 4px;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: var(--button-icon-color);
+  opacity: 0.65;
+}
+
+.input-icon-button:hover {
+  opacity: 1;
+}
+
 .textbox {
   display: table-cell;
   width: 100%;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import { Tab, TabList, TabPanel, Tabs } from "react-tabs"
 import { Tooltip } from "react-tooltip"
 import { Config, defaultConfig, getCaptureDeviceChannelCount } from "./camilladsp/config"
 import { CompactView, getViewMode, setViewMode, ViewMode } from "./compactview"
+import type { CustomPageComponent } from "./custom-pages/types"
 import { DashboardView } from "./dashboardview"
 import { installDemoBackend } from "./demo/mockBackend"
 import { DevicesTab } from "./devicestab"
@@ -31,7 +32,6 @@ import { Update } from "./utilities/common"
 import { Errors, NoErrors } from "./utilities/errors"
 import { loadStartupConfig } from "./utilities/files"
 import { delayedExecutor, ErrorBoundary, MdiButton, MdiIcon } from "./utilities/ui-components"
-import type { CustomPageComponent } from "./custom-pages/types"
 
 const customPageModules = import.meta.glob<{ default: CustomPageComponent }>(
   "./custom-pages/*.tsx",

--- a/src/pipeline/pipelinetab.tsx
+++ b/src/pipeline/pipelinetab.tsx
@@ -23,6 +23,7 @@ import {
   Processors,
   ProcessorStep,
 } from "../camilladsp/config"
+import { evalFilterStep } from "../camilladsp/eval"
 import { moveItem, moveItemDown, moveItemUp } from "../utilities/arrays"
 import { ChartContent, ChartPopup } from "../utilities/chart"
 import { Update } from "../utilities/common"
@@ -102,26 +103,19 @@ export class PipelineTab extends React.Component<
 
   plotFilterStep = (index: number, samplerate?: number, channels?: number) => {
     const config = this.props.config
-    fetch("/api/evalfilterstep", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        index: index,
-        config: config,
-        samplerate: samplerate || config.devices.samplerate,
-        channels: channels || this.state.capture_channels,
-        volume: this.state.plot_at_volume,
-      }),
+    evalFilterStep(config, index, {
+      name: `Filterstep ${index}`,
+      samplerate: samplerate || config.devices.samplerate,
+      channels: channels || this.state.capture_channels,
+      volume: this.state.plot_at_volume,
     }).then(
-      (result) =>
-        result.json().then((data) =>
-          this.setState({
-            plotFilterStep: true,
-            stepIndex: index,
-            data: data,
-          }),
-        ),
-      (error) => console.log("Failed", error),
+      (data) =>
+        this.setState({
+          plotFilterStep: true,
+          stepIndex: index,
+          data: data,
+        }),
+      (error) => console.log("Filter step evaluation failed", error),
     )
   }
 

--- a/src/utilities/chart.tsx
+++ b/src/utilities/chart.tsx
@@ -84,6 +84,7 @@ export interface ChartContent {
    * for a convolution filter, absent for anything evaluated in closed form.
    */
   phaseFloor?: number
+  /** Group delay in ms, one value per frequency in `f_groupdelay`. */
   groupdelay?: number[]
   f_groupdelay?: number[]
 }

--- a/src/utilities/chart.tsx
+++ b/src/utilities/chart.tsx
@@ -75,8 +75,10 @@ export interface ChartContent {
   f: number[]
   magnitude?: number[]
   phase?: number[]
-  impulse?: number[]
-  time: number[]
+  // the impulse response arrives from the backend as raw float64 and is kept
+  // as a view over those bytes, so these are typed arrays rather than lists
+  impulse?: ArrayLike<number>
+  time: ArrayLike<number>
   groupdelay?: number[]
   f_groupdelay?: number[]
 }
@@ -108,8 +110,10 @@ export function Chart(props: { data: ChartContent; onChange: (item: string) => v
 
   const data: ChartData<"scatter"> = { labels: [props.data.name], datasets: [] }
 
-  function make_pointlist(xvect: number[], yvect: number[], scaling_x: number, scaling_y: number) {
-    return xvect.map((x, idx) => ({
+  function make_pointlist(xvect: ArrayLike<number>, yvect: ArrayLike<number>, scaling_x: number, scaling_y: number) {
+    // Array.from, not map: xvect may be a Float64Array, whose own map would
+    // coerce these points back to numbers
+    return Array.from(xvect, (x, idx) => ({
       x: scaling_x * x,
       y: scaling_y * yvect[idx],
     }))

--- a/src/utilities/chart.tsx
+++ b/src/utilities/chart.tsx
@@ -120,15 +120,13 @@ export function Chart(props: { data: ChartContent; onChange: (item: string) => v
     const phasedat = props.data.phase
     const delaydat = props.data.groupdelay
 
-    const table = props.data.f.map((f, i) => {
-      let mag: number | null = null
-      if (magdat !== undefined) mag = magdat[i]
-      let phase: number | null = null
-      if (phasedat !== undefined) phase = phasedat[i]
-      let delay: number | null = null
-      if (delaydat !== undefined) delay = delaydat[i]
-      return [f, mag, phase, delay]
-    })
+    // a blanked point, deep below a convolution filter's passband where the
+    // phase is not readable, is an empty field rather than the text NaN
+    const value = (values: number[] | undefined, i: number) => {
+      const v = values === undefined ? undefined : values[i]
+      return v === undefined || !Number.isFinite(v) ? null : v
+    }
+    const table = props.data.f.map((f, i) => [f, value(magdat, i), value(phasedat, i), value(delaydat, i)])
     const csvContent =
       "data:text/csv;charset=utf-8,frequency,magnitude,phase,groupdelay\n" +
       table.map((row) => row.join(",")).join("\n")

--- a/src/utilities/chart.tsx
+++ b/src/utilities/chart.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useMemo, useRef } from "react"
-import { mdiHome, mdiImage, mdiTable } from "@mdi/js"
+import React, { useCallback, useMemo, useRef, useState } from "react"
+import { mdiEye, mdiEyeOff, mdiHome, mdiImage, mdiTable } from "@mdi/js"
 import {
   Chart as ChartJS,
   Legend,
@@ -79,6 +79,11 @@ export interface ChartContent {
   // as a view over those bytes, so these are typed arrays rather than lists
   impulse?: ArrayLike<number>
   time: ArrayLike<number>
+  /**
+   * The level, in dB, below which the phase is aliasing rather than phase. Set
+   * for a convolution filter, absent for anything evaluated in closed form.
+   */
+  phaseFloor?: number
   groupdelay?: number[]
   f_groupdelay?: number[]
 }
@@ -91,6 +96,7 @@ export interface FilterOption {
 
 export function Chart(props: { data: ChartContent; onChange: (item: string) => void }) {
   const chartRef = useRef<ChartJS<"scatter"> & { resetZoom: () => void }>(null)
+  const [hideUnreadablePhase, setHideUnreadablePhase] = useState(true)
   const downloadPlot = useCallback(() => {
     const link = document.createElement("a")
     link.download = props.data.name.replace(/\s/g, "_") + ".png"
@@ -140,12 +146,17 @@ export function Chart(props: { data: ChartContent; onChange: (item: string) => v
     link.click()
   }, [props.data.f, props.data.magnitude, props.data.name, props.data.phase, props.data.groupdelay])
 
+  const phaseFloor = props.data.phaseFloor
+  const magnitude = props.data.magnitude
+  // only worth offering when there is something to hide
+  const hasUnreadablePhase =
+    phaseFloor !== undefined && magnitude !== undefined && magnitude.some((value) => value < phaseFloor)
+
   const styles = cssStyles()
   const gainColor = styles.getPropertyValue("--gain-color")
   const phaseColor = styles.getPropertyValue("--phase-color")
   const impulseColor = styles.getPropertyValue("--impulse-color")
   const groupdelayColor = styles.getPropertyValue("--groupdelay-color")
-  const magnitude = props.data.magnitude
   if (magnitude) {
     const gainpoints = make_pointlist(props.data.f, magnitude, 1.0, 1.0)
     data.datasets.push({
@@ -163,7 +174,17 @@ export function Chart(props: { data: ChartContent; onChange: (item: string) => v
   }
   const phase = props.data.phase
   if (phase) {
-    const phasepoints = make_pointlist(props.data.f, phase, 1.0, 1.0)
+    // Below the floor the phase turns a full circle between neighbouring nulls
+    // and the grid samples it far too sparsely to show that, so what would be
+    // drawn is the aliasing. The values are right, so it is offered as a
+    // choice rather than simply dropped. Group delay is not offered: it is
+    // read from a blanked phase whatever this is set to, since a prediction
+    // carried through the aliased region moves the readable part of the curve.
+    const hidden =
+      hideUnreadablePhase && phaseFloor !== undefined && magnitude !== undefined
+        ? phase.map((value, n) => (magnitude[n] < phaseFloor ? NaN : value))
+        : phase
+    const phasepoints = make_pointlist(props.data.f, hidden, 1.0, 1.0)
     data.datasets.push({
       label: "Phase",
       fill: false,
@@ -506,6 +527,13 @@ export function Chart(props: { data: ChartContent; onChange: (item: string) => v
       <Scatter data={data} options={options} ref={chartRef} />
       <MdiButton icon={mdiImage} tooltip="Save plot as image" onClick={downloadPlot} />
       <MdiButton icon={mdiTable} tooltip="Save plot data as csv" onClick={downloadData} />
+      {hasUnreadablePhase && (
+        <MdiButton
+          icon={hideUnreadablePhase ? mdiEyeOff : mdiEye}
+          tooltip={hideUnreadablePhase ? "Show unreliable phase" : "Hide unreliable phase"}
+          onClick={() => setHideUnreadablePhase(!hideUnreadablePhase)}
+        />
+      )}
       <MdiButton icon={mdiHome} tooltip="Reset zoom and pan" onClick={resetView} />
       <ReactTooltip />
     </>

--- a/src/utilities/ui-components.tsx
+++ b/src/utilities/ui-components.tsx
@@ -552,21 +552,15 @@ export function LabelListOption(props: {
       <label htmlFor={props.desc} className="setting-label">
         {props.desc}
       </label>
-      <OptionalTextInput
-        value={props.value}
-        tooltip="Optional labels for individual channels"
-        className="setting-input"
-        style={{ width: "87%" }}
-        onChange={updateChannelLabels}
-      />
-      <MdiButton
-        icon={mdiMenuDown}
-        tooltip="Expand channel list"
-        onClick={props.onButtonClick}
-        className="setting-button"
-        style={{ width: "13%" }}
-        buttonSize="small"
-      />
+      <div className="setting-input device-option-row">
+        <InputWithIcon icon={mdiMenuDown} tooltip="Expand channel list" onClick={props.onButtonClick}>
+          <OptionalTextInput
+            value={props.value}
+            tooltip="Optional labels for individual channels"
+            onChange={updateChannelLabels}
+          />
+        </InputWithIcon>
+      </div>
       <ErrorMessage message={props.error} />
     </div>
   )
@@ -999,18 +993,30 @@ export function TextOption(props: {
   warning?: string
   desc: string
   tooltip: string
+  icon?: { path: string; tooltip: string; onClick: () => void }
   onChange: (value: string) => void
 }) {
+  const input = (
+    <TextInput
+      className={props.icon ? undefined : "setting-input"}
+      value={props.value}
+      tooltip={props.tooltip}
+      style={props.error ? ERROR_BACKGROUND_STYLE : undefined}
+      onChange={props.onChange}
+    />
+  )
   return (
     <>
       <OptionLine desc={props.desc} tooltip={props.tooltip}>
-        <TextInput
-          className="setting-input"
-          value={props.value}
-          tooltip={props.tooltip}
-          style={props.error ? ERROR_BACKGROUND_STYLE : undefined}
-          onChange={props.onChange}
-        />
+        {props.icon ? (
+          <div className="setting-input device-option-row">
+            <InputWithIcon icon={props.icon.path} tooltip={props.icon.tooltip} onClick={props.icon.onClick}>
+              {input}
+            </InputWithIcon>
+          </div>
+        ) : (
+          input
+        )}
       </OptionLine>
       <ErrorMessage message={props.error} />
       <WarningMessage message={props.warning} />
@@ -1086,6 +1092,34 @@ export function TextInput(props: {
       style={props.style}
       onChange={(e) => props.onChange(e.target.value)}
     />
+  )
+}
+
+/**
+ * Wraps an input and places a clickable icon inside it, at the right edge.
+ * Used for the pickers that fill in the field, see `.input-with-icon` in index.css.
+ */
+export function InputWithIcon(props: { icon: string; tooltip: string; onClick: () => void; children: ReactNode }) {
+  return (
+    <div className="input-with-icon">
+      {props.children}
+      <span
+        className="input-icon-button"
+        role="button"
+        tabIndex={0}
+        data-tooltip-html={props.tooltip}
+        data-tooltip-id="main-tooltip"
+        onClick={props.onClick}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault()
+            props.onClick()
+          }
+        }}
+      >
+        <Icon path={props.icon} size="18px" />
+      </span>
+    </div>
   )
 }
 


### PR DESCRIPTION
Moves the filter evaluator out of the backend into `src/camilladsp/eval/`, so a plot needs no round trip and no debounce, except for a Conv that reads a coefficient file.

- `evalFilter` / `evalFilterStep` return a `ChartContent`, async only because a file backed Conv fetches its coefficients from `POST /api/convcoeffs`
- coefficients are cached on the Conv parameters plus samplerate and channels, and dropped when the files on disk change
- `properties.test.ts` asserts closed form properties rather than captured curves, and `variants.json` keeps the Python schemas coupled to the TypeScript evaluator
- corrects four errors in the plotted curves: a 0.2% frequency stretch in the Conv interpolation, group delay read off an unwrap that carried its errors forward, a Conv bulk delay unwrapped on too coarse a grid, and an FFT too short to resolve the knee of a long filter
- phase and group delay are left out more than 150 dB below a convolution filter's peak, where the plot grid can only alias them
- demo mode plots real responses

Pairs with the camillagui-backend branch of the same name.
